### PR TITLE
feat: 모바일 레이아웃 깨짐 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,16 +11,16 @@ import NotFoundPage from "./pages/NotFoundPage"; // Existing file
 
 // Simple Footer for completeness
 const Footer = () => (
-  <footer style={{ background: 'var(--color-navy-900)', color: 'white', padding: '60px 0', marginTop: 'auto' }}>
-    <div className="container" style={{ opacity: 0.7 }}>
-      <div style={{ marginBottom: '24px', fontWeight: 700, fontSize: '1.2rem' }}>ECOGAD</div>
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '40px', fontSize: '0.9rem' }}>
+  <footer className="site-footer">
+    <div className="container footer-inner">
+      <div className="footer-brand">ECOGAD</div>
+      <div className="footer-grid">
         <div>
           <p>경기도 화성시 동탄첨단산업1로 27</p>
           <p>대표전화: 031-123-4567 | 팩스: 031-123-4568</p>
           <p>이메일: sales@ecogad.co.kr</p>
         </div>
-        <div style={{ textAlign: 'right' }}>
+        <div className="footer-copyright">
           <p>Copyright © 2026 ECOGAD. All rights reserved.</p>
         </div>
       </div>
@@ -30,9 +30,9 @@ const Footer = () => (
 
 export default function App() {
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+    <div className="site-shell">
       <Header />
-      <main style={{ flex: 1 }}>
+      <main className="site-main">
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/company" element={<CompanyPage />} />

--- a/src/components/common/EmptyState.jsx
+++ b/src/components/common/EmptyState.jsx
@@ -1,43 +1,34 @@
-import React from 'react';
+import React from "react";
 
 const EmptyState = ({ title, message, actionText, onAction }) => {
   return (
-    <div style={{
-      textAlign: 'center',
-      padding: '80px 24px',
-      background: 'var(--color-navy-50)',
-      borderRadius: 'var(--radius-md)',
-      border: '1px dashed var(--color-gray-200)',
-      margin: '40px 0'
-    }}>
-      <div style={{
-        width: '64px',
-        height: '64px',
-        background: 'var(--color-gray-100)',
-        borderRadius: '50%',
-        margin: '0 auto 24px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: 'var(--color-gray-600)',
-        fontSize: '1.5rem',
-      }}>
-        {/* Simple SVG Icon for 'Empty Box' */}
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
-          <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
-          <line x1="12" y1="22.08" x2="12" y2="12"></line>
+    <div className="empty-state">
+      <div className="empty-icon" aria-hidden="true">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+          <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+          <line x1="12" y1="22.08" x2="12" y2="12" />
         </svg>
       </div>
-      <h3 className="heading-3" style={{ marginBottom: '8px', color: 'var(--color-navy-800)' }}>{title || '등록된 데이터가 없습니다'}</h3>
-      <p className="body-text" style={{ maxWidth: '400px', margin: '0 auto 24px', fontSize: '0.95rem' }}>
-        {message || '현재 카테고리에 등록된 제품이 없습니다. 관리자에게 문의하거나 나중에 다시 확인해 주세요.'}
+      <h3 className="heading-3 empty-title">{title || "등록된 데이터가 없습니다"}</h3>
+      <p className="body-text empty-message">
+        {message || "현재 카테고리에 등록된 제품이 없습니다. 관리자에게 문의하거나 나중에 다시 확인해 주세요."}
       </p>
-      {actionText && (
+      {actionText ? (
         <button className="btn btn-outline" onClick={onAction}>
           {actionText}
         </button>
-      )}
+      ) : null}
     </div>
   );
 };

--- a/src/components/common/PageHero.jsx
+++ b/src/components/common/PageHero.jsx
@@ -1,46 +1,25 @@
-import React from 'react';
+import React from "react";
 
-const PageHero = ({ title, subtitle, bgImage }) => {
+const PageHero = ({ title, subtitle, bgImage, description, imageUrl, imageAlt }) => {
+  const summary = subtitle ?? description;
+  const background = bgImage ?? imageUrl;
+
   return (
-    <div style={{
-      position: 'relative',
-      height: '400px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      color: '#ffffff',
-      overflow: 'hidden',
-      marginTop: '80px', // header height
-      textAlign: 'center',
-    }}>
-      {/* Background Image with Dark Overlay */}
-      <div style={{
-        position: 'absolute',
-        top: 0, left: 0, width: '100%', height: '100%',
-        backgroundImage: `url(${bgImage})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        filter: 'brightness(0.35)', // Darken for readability
-        zIndex: 1,
-      }}></div>
+    <section className="page-hero" aria-label={title}>
+      <div
+        className="page-hero-bg"
+        style={{
+          backgroundImage: `url(${background})`
+        }}
+        role="img"
+        aria-label={imageAlt ?? title}
+      />
 
-      {/* Content */}
-      <div className="container" style={{ position: 'relative', zIndex: 2 }}>
-        <h1 style={{ 
-          fontSize: '3rem', 
-          fontWeight: '800', 
-          marginBottom: '1rem',
-          letterSpacing: '-0.02em',
-        }}>{title}</h1>
-        <p style={{ 
-          fontSize: '1.25rem', 
-          opacity: 0.9, 
-          maxWidth: '700px', 
-          margin: '0 auto', 
-          fontWeight: 400 
-        }}>{subtitle}</p>
+      <div className="container page-hero-content">
+        <h1>{title}</h1>
+        {summary ? <p>{summary}</p> : null}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -1,5 +1,5 @@
-import { NavLink, Outlet } from "react-router-dom";
-import { useEffect } from "react";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
 
 const navItems = [
   { to: "/company", label: "회사소개" },
@@ -9,6 +9,9 @@ const navItems = [
 ];
 
 export default function AppLayout() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const location = useLocation();
+
   useEffect(() => {
     const scriptId = "organization-jsonld";
     if (document.getElementById(scriptId)) {
@@ -28,6 +31,10 @@ export default function AppLayout() {
     document.head.appendChild(script);
   }, []);
 
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [location.pathname]);
+
   return (
     <div className="site-shell">
       <header className="site-header">
@@ -35,7 +42,22 @@ export default function AppLayout() {
           <NavLink to="/" className="brand" aria-label="ecogad 홈으로 이동">
             ECOGAD
           </NavLink>
-          <nav className="global-nav" aria-label="메인 메뉴">
+          <button
+            type="button"
+            className="menu-toggle"
+            aria-label="메뉴 열기"
+            aria-expanded={mobileMenuOpen}
+            onClick={() => setMobileMenuOpen((prev) => !prev)}
+          >
+            <span />
+            <span />
+            <span />
+          </button>
+
+          <nav
+            className={`global-nav ${mobileMenuOpen ? "is-open" : ""}`}
+            aria-label="메인 메뉴"
+          >
             <ul>
               {navItems.map((item) => (
                 <li key={item.to}>

--- a/src/layouts/Header.jsx
+++ b/src/layouts/Header.jsx
@@ -1,73 +1,75 @@
-import React, { useState, useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import React, { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+
+const navLinks = [
+  { name: "회사소개", path: "/company" },
+  { name: "제품 및 서비스", path: "/products" },
+  { name: "견적 문의", path: "/inquiry" },
+  { name: "공지사항", path: "/notices" }
+];
 
 const Header = () => {
   const location = useLocation();
   const [scrolled, setScrolled] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
       setScrolled(window.scrollY > 20);
     };
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
-  const navLinks = [
-    { name: '회사소개', path: '/company' },
-    { name: '제품 및 서비스', path: '/products' },
-    { name: '견적 문의', path: '/inquiry' },
-    { name: '공지사항', path: '/notices' },
-  ];
-
-  const headerStyle = {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
-    zIndex: 1000,
-    backgroundColor: scrolled ? 'rgba(255, 255, 255, 0.95)' : 'rgba(255, 255, 255, 0.8)',
-    backdropFilter: 'blur(12px)',
-    borderBottom: scrolled ? '1px solid var(--color-gray-200)' : '1px solid transparent',
-    transition: 'all 0.3s ease',
-    height: 'var(--header-height)',
-    display: 'flex',
-    alignItems: 'center',
-  };
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
 
   return (
-    <header style={headerStyle}>
-      <div className="container" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
-        {/* Logo */}
-        <Link to="/" style={{ fontSize: '1.5rem', fontWeight: 800, color: 'var(--color-navy-900)', display: 'flex', alignItems: 'center', gap: '8px' }}>
-          <div style={{ width: '24px', height: '24px', background: 'var(--color-blue-600)', borderRadius: '4px' }}></div>
+    <header className={`site-header ${scrolled ? "is-scrolled" : ""}`}>
+      <div className="container header-inner">
+        <Link to="/" className="brand" aria-label="ecogad 홈으로 이동">
+          <span className="brand-mark" aria-hidden="true" />
           ECOGAD
         </Link>
 
-        {/* Navigation */}
-        <nav>
-          <ul style={{ display: 'flex', gap: '32px' }}>
-            {navLinks.map((link) => (
-              <li key={link.name}>
-                <Link 
-                  to={link.path} 
-                  style={{
-                    fontSize: '1rem',
-                    fontWeight: 600,
-                    color: location.pathname.startsWith(link.path) ? 'var(--color-blue-600)' : 'var(--color-gray-600)',
-                    position: 'relative',
-                    padding: '8px 0',
-                  }}
-                >
-                  {link.name}
-                  {location.pathname.startsWith(link.path) && (
-                    <span style={{
-                      position: 'absolute', bottom: 0, left: 0, width: '100%', height: '2px', background: 'var(--color-blue-600)'
-                    }}></span>
-                  )}
-                </Link>
-              </li>
-            ))}
+        <button
+          type="button"
+          className={`menu-toggle ${menuOpen ? "is-open" : ""}`}
+          aria-label="메뉴 열기"
+          aria-expanded={menuOpen}
+          aria-controls="global-navigation"
+          onClick={() => setMenuOpen((prev) => !prev)}
+        >
+          <span />
+          <span />
+          <span />
+        </button>
+
+        <nav
+          id="global-navigation"
+          className={`global-nav ${menuOpen ? "is-open" : ""}`}
+          aria-label="메인 메뉴"
+        >
+          <ul>
+            {navLinks.map((link) => {
+              const isActive =
+                location.pathname === link.path ||
+                location.pathname.startsWith(`${link.path}/`);
+
+              return (
+                <li key={link.path}>
+                  <Link
+                    to={link.path}
+                    className={`nav-link ${isActive ? "active" : ""}`}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    {link.name}
+                  </Link>
+                </li>
+              );
+            })}
           </ul>
         </nav>
       </div>

--- a/src/pages/CompanyPage.jsx
+++ b/src/pages/CompanyPage.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
-import PageHero from '../components/common/PageHero';
-import SectionHeader from '../components/common/SectionHeader';
+import React from "react";
+import { Link } from "react-router-dom";
+import PageHero from "../components/common/PageHero";
+import SectionHeader from "../components/common/SectionHeader";
 
 const histories = [
   { year: "2025", title: "사업 확장 및 고도화", text: "전국 유지보수 통합 서비스 표준 프로세스 운영 개시" },
@@ -11,115 +12,129 @@ const histories = [
 
 const CompanyPage = () => {
   return (
-    <div>
-      <PageHero 
-        title="Who We Are" 
+    <div className="company-page">
+      <PageHero
+        title="Who We Are"
         subtitle="가장 맑은 숨으로 내일을 여는 기술, 에코가드의 철학입니다."
         bgImage="https://images.unsplash.com/photo-1565043589221-1a6fd9ae45c7?auto=format&fit=crop&w=1800&q=80"
+        imageAlt="산업 시설 전경"
       />
 
-      {/* 1. CEO Greeting Section - Cambridge Style Framing */}
-      <section className="section" style={{ backgroundColor: '#fff', position: 'relative' }}>
-        <div className="container" style={{ display: 'grid', gridTemplateColumns: '1.2fr 1fr', gap: '80px', alignItems: 'center' }}>
+      <section className="section company-ceo-section">
+        <div className="container company-ceo-grid">
           <div>
-            <span className="section-eyebrow" style={{ color: 'var(--color-blue-600)' }}>CEO GREETING</span>
-            <h2 className="heading-1" style={{ fontSize: '2.75rem', lineHeight: '1.3', marginBottom: '32px' }}>
-              공정의 안정성과 근로자의 건강을<br />
+            <span className="section-eyebrow company-ceo-eyebrow">CEO GREETING</span>
+            <h2 className="heading-1 company-ceo-title">
+              공정의 안정성과 근로자의 건강을
+              <br />
               지키는 가장 완벽한 필터링 기술.
             </h2>
-            <div className="body-text" style={{ fontSize: '1.1rem', lineHeight: '1.8' }}>
-              <p style={{ marginBottom: '24px' }}>
-                안녕하십니까? 에코가드 대표이사 김철수입니다.<br />
+            <div className="body-text company-ceo-body">
+              <p>
+                안녕하십니까? 에코가드 대표이사 김철수입니다.
                 우리가 숨 쉬는 공기는 단순한 환경을 넘어 산업의 품질과 생명에 직결됩니다.
               </p>
-              <p style={{ marginBottom: '24px' }}>
-                캠브리지 필터의 정밀한 엔지니어링 정신을 이어받아, 에코가드는 0.1µm의 입자 하나까지 놓치지 않는 고성능 필터 국산화에 매진해왔습니다. 반도체, 제약, 의료, 그리고 대형 공공 인프라에 이르기까지 에코가드의 기술이 닿지 않는 곳이 없습니다.
+              <p>
+                캠브리지 필터의 정밀한 엔지니어링 정신을 이어받아, 에코가드는 0.1μm의 입자
+                하나까지 놓치지 않는 고성능 필터 국산화에 매진해왔습니다. 반도체, 제약, 의료,
+                그리고 대형 공공 인프라에 이르기까지 에코가드의 기술이 닿지 않는 곳이 없습니다.
               </p>
               <p>
-                우리는 단순한 필터 제조사를 넘어, 고객사의 공정 안정성을 위한 최적의 '공조 솔루션 파트너'가 될 것을 약속드립니다. 언제나 가장 맑은 공기로 여러분의 비즈니스에 보탬이 되겠습니다.
+                우리는 단순한 필터 제조사를 넘어, 고객사의 공정 안정성을 위한 최적의
+                공조 솔루션 파트너가 될 것을 약속드립니다. 언제나 가장 맑은 공기로
+                여러분의 비즈니스에 보탬이 되겠습니다.
               </p>
             </div>
-            
+
             <div className="ceo-signature">
-              <span className="signature-line"></span>
-              <span style={{ fontWeight: 600, color: 'var(--color-navy-900)' }}>에코가드 주식회사 대표이사</span>
+              <span className="signature-line" />
+              <span className="company-ceo-role">에코가드 주식회사 대표이사</span>
               <span className="signature-text">Kim Chul Soo</span>
             </div>
           </div>
-          
-          <div style={{ position: 'relative', height: '100%', minHeight: '500px' }}>
-            {/* Subtle background rectangle for the image */}
-            <div style={{ 
-              position: 'absolute', top: '40px', left: '40px', right: '-40px', bottom: '-40px',
-              background: 'var(--color-navy-50)', zIndex: 1, borderRadius: 'var(--radius-md)'
-            }}></div>
-            <img 
-              src="https://images.unsplash.com/photo-1556761175-5973dc0f32e7?auto=format&fit=crop&w=1632&q=80" 
-              alt="CEO Signature Pose" 
-              style={{ width: '100%', height: '500px', objectFit: 'cover', position: 'relative', zIndex: 2, borderRadius: 'var(--radius-md)', filter: 'grayscale(30%) contrast(1.1)' }}
+
+          <div className="company-ceo-image-wrap">
+            <div className="company-ceo-image-bg" aria-hidden="true" />
+            <img
+              src="https://images.unsplash.com/photo-1556761175-5973dc0f32e7?auto=format&fit=crop&w=1632&q=80"
+              alt="CEO 이미지"
+              className="company-ceo-image"
+              loading="lazy"
             />
           </div>
         </div>
       </section>
 
-      {/* 2. Philosophy / Vision - Cambridge Style Grid */}
       <section className="section bg-gray">
         <div className="container">
-          <SectionHeader 
-            eyebrow="MANAGEMENT PHILOSOPHY" 
-            title="기업 이념" 
-            description="에코가드는 세 가지 핵심 가치를 바탕으로 고객의 신뢰에 보답합니다." 
+          <SectionHeader
+            eyebrow="MANAGEMENT PHILOSOPHY"
+            title="기업 이념"
+            description="에코가드는 세 가지 핵심 가치를 바탕으로 고객의 신뢰에 보답합니다."
           />
           <div className="philosophy-grid">
-            <div className="philosophy-item">
+            <article className="philosophy-item">
               <span className="philosophy-number">01</span>
               <h3 className="heading-3">Integrity (무결성)</h3>
-              <p className="body-text" style={{ fontSize: '0.95rem' }}>제품의 성능은 곧 신뢰입니다. 타협하지 않는 품질 기준으로 무결점 필터만을 생산합니다.</p>
-            </div>
-            <div className="philosophy-item">
+              <p className="body-text">
+                제품의 성능은 곧 신뢰입니다. 타협하지 않는 품질 기준으로 무결점 필터만을 생산합니다.
+              </p>
+            </article>
+            <article className="philosophy-item">
               <span className="philosophy-number">02</span>
               <h3 className="heading-3">Innovation (혁신)</h3>
-              <p className="body-text" style={{ fontSize: '0.95rem' }}>정체된 기술은 도태됩니다. 나노 소재 및 스마트 모니터링 시스템 등 혁신을 선도합니다.</p>
-            </div>
-            <div className="philosophy-item">
+              <p className="body-text">
+                정체된 기술은 도태됩니다. 나노 소재 및 스마트 모니터링 시스템 등 혁신을 선도합니다.
+              </p>
+            </article>
+            <article className="philosophy-item">
               <span className="philosophy-number">03</span>
               <h3 className="heading-3">Sustainability (지속가능성)</h3>
-              <p className="body-text" style={{ fontSize: '0.95rem' }}>환경을 보호하는 필터가 되어야 합니다. 에너지 효율 극대화와 친환경 소재 적용에 앞장섭니다.</p>
-            </div>
+              <p className="body-text">
+                환경을 보호하는 필터가 되어야 합니다. 에너지 효율 극대화와 친환경 소재 적용에 앞장섭니다.
+              </p>
+            </article>
           </div>
         </div>
       </section>
 
-      {/* 3. History Section - Minimalistic Line Timeline */}
       <section className="section">
         <div className="container">
-          <SectionHeader eyebrow="HISTORY" title="연혁" description="에코가드는 고객과 함께 정직한 성장의 길을 걸어왔습니다." />
+          <SectionHeader
+            eyebrow="HISTORY"
+            title="연혁"
+            description="에코가드는 고객과 함께 정직한 성장의 길을 걸어왔습니다."
+          />
           <div className="history-container">
-            {histories.map((h, idx) => (
-              <div key={idx} className="history-item">
-                <div className="history-year">{h.year}</div>
-                <div className="history-dot"></div>
+            {histories.map((history) => (
+              <article key={history.year} className="history-item">
+                <div className="history-year">{history.year}</div>
+                <div className="history-dot" />
                 <div className="history-content">
-                  <h4 style={{ color: 'var(--color-blue-600)' }}>{h.title}</h4>
-                  <p className="body-text">{h.text}</p>
+                  <h4>{history.title}</h4>
+                  <p className="body-text">{history.text}</p>
                 </div>
-              </div>
+              </article>
             ))}
           </div>
         </div>
       </section>
 
-      {/* 4. Global Vision Call to Action (Cambridge Style) */}
-      <section className="section" style={{ backgroundColor: 'var(--color-navy-900)', color: 'white', textAlign: 'center' }}>
-        <div className="container">
-          <span className="section-eyebrow" style={{ color: 'var(--color-cyan-500)' }}>GLOBAL NETWORK</span>
-          <h2 className="heading-2" style={{ color: 'white', marginBottom: '24px' }}>한국을 넘어 세계 최고의 공기질 솔루션으로.</h2>
-          <p className="body-text" style={{ color: 'rgba(255,255,255,0.7)', maxWidth: '700px', margin: '0 auto 40px' }}>
-            에코가드는 이미 동남아시아 및 중동 시장의 주요 클린룸 프로젝트를 성공적으로 수행하며 세계적인 기술력을 인정받고 있습니다.
+      <section className="section company-cta-section">
+        <div className="container company-cta-container">
+          <span className="section-eyebrow company-cta-eyebrow">GLOBAL NETWORK</span>
+          <h2 className="heading-2 company-cta-title">한국을 넘어 세계 최고의 공기질 솔루션으로.</h2>
+          <p className="body-text company-cta-desc">
+            에코가드는 동남아시아 및 중동 시장의 주요 클린룸 프로젝트를 수행하며
+            세계적인 기술력을 인정받고 있습니다.
           </p>
-          <div style={{ display: 'flex', gap: '16px', justifyContent: 'center' }}>
-            <button className="btn btn-primary" onClick={() => window.location.href='/products'}>제품 라인업 확인</button>
-            <button className="btn btn-outline" style={{ background: 'transparent', color: 'white', borderColor: 'rgba(255,255,255,0.4)' }} onClick={() => window.location.href='/inquiry'}>지사 및 네트워크 문의</button>
+          <div className="company-cta-actions">
+            <Link to="/products" className="btn btn-primary">
+              제품 라인업 확인
+            </Link>
+            <Link to="/inquiry" className="btn btn-outline btn-outline-light">
+              지사 및 네트워크 문의
+            </Link>
           </div>
         </div>
       </section>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,148 +1,166 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import SectionHeader from '../components/common/SectionHeader';
+import React from "react";
+import { Link } from "react-router-dom";
+import SectionHeader from "../components/common/SectionHeader";
+
+const strengths = [
+  {
+    num: "99.999%",
+    title: "ULPA Performance",
+    desc: "0.1μm 입자까지 완벽하게 제어하는 초고성능 여과 기술"
+  },
+  {
+    num: "35% Lower",
+    title: "Energy Efficient",
+    desc: "독자적인 저압손 설계를 통한 송풍기 전력 소모 혁신적 절감"
+  },
+  {
+    num: "ISO Class 1",
+    title: "Cleanliness Certified",
+    desc: "최첨단 반도체 공정에 적합한 세계 최고 수준의 청정도 보장"
+  }
+];
 
 const HomePage = () => {
   return (
-    <div>
-      {/* 1. Majestic Hero Section - Cambridge style depth */}
-      <section style={{ 
-        position: 'relative', 
-        height: '100vh', 
-        display: 'flex', 
-        alignItems: 'center', 
-        color: 'white',
-        marginTop: '-80px',
-        overflow: 'hidden'
-      }}>
-        {/* Background with subtle zoom animation or static high-res */}
-        <div style={{
-          position: 'absolute', top: 0, left: 0, width: '100%', height: '100%',
-          backgroundImage: 'url(https://images.unsplash.com/photo-1581092786450-7ef25f140997?auto=format&fit=crop&w=1800&q=80)',
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          filter: 'brightness(0.3)',
-          zIndex: 1
-        }}></div>
-        
-        <div className="container" style={{ position: 'relative', zIndex: 2 }}>
-          <div style={{ maxWidth: '800px' }}>
-            <span className="section-eyebrow" style={{ color: 'var(--color-cyan-500)', fontSize: '1.1rem', letterSpacing: '0.3em', marginBottom: '24px', display: 'block' }}>
-              ENGINEERING PURITY SINCE 2012
-            </span>
-            <h1 className="display-1" style={{ marginBottom: '32px', color: 'white', fontSize: '4.5rem', lineHeight: '1.1' }}>
-              The Standard of<br />
-              <span style={{ color: 'var(--color-blue-600)' }}>Industrial Purity.</span>
-            </h1>
-            <p className="body-text" style={{ fontSize: '1.4rem', color: 'rgba(255,255,255,0.8)', lineHeight: '1.6', marginBottom: '48px', fontWeight: 300 }}>
-              반도체 클린룸에서 공항까지, 에코가드의 초정밀 필터 솔루션은<br /> 
-              산업의 품질과 생명을 지키는 가장 완벽한 기준이 됩니다.
-            </p>
-            <div style={{ display: 'flex', gap: '20px' }}>
-              <Link to="/products" className="btn btn-primary" style={{ padding: '18px 48px', borderRadius: '0' }}>
-                EXPLORE SOLUTIONS
-              </Link>
-              <Link to="/company" className="btn" style={{ 
-                padding: '18px 48px', 
-                border: '1px solid rgba(255,255,255,0.3)', 
-                color: 'white',
-                borderRadius: '0'
-              }}>
-                ABOUT ECOGAD
-              </Link>
-            </div>
+    <div className="home-page">
+      <section className="home-hero" aria-label="메인 소개">
+        <div
+          className="home-hero-bg"
+          style={{
+            backgroundImage:
+              "url(https://images.unsplash.com/photo-1581092786450-7ef25f140997?auto=format&fit=crop&w=1800&q=80)"
+          }}
+          aria-hidden="true"
+        />
+
+        <div className="container home-hero-content">
+          <span className="section-eyebrow home-hero-eyebrow">ENGINEERING PURITY SINCE 2012</span>
+          <h1 className="display-1 home-hero-title">
+            The Standard of
+            <br />
+            <span>Industrial Purity.</span>
+          </h1>
+          <p className="body-text home-hero-desc">
+            반도체 클린룸에서 공항까지, 에코가드의 초정밀 필터 솔루션은
+            <br className="desktop-only" />
+            산업의 품질과 생명을 지키는 가장 완벽한 기준이 됩니다.
+          </p>
+          <div className="home-hero-actions">
+            <Link to="/products" className="btn btn-primary">
+              EXPLORE SOLUTIONS
+            </Link>
+            <Link to="/company" className="btn btn-ghost-light">
+              ABOUT ECOGAD
+            </Link>
           </div>
         </div>
-        
-        {/* Bottom scroll indicator */}
-        <div style={{ position: 'absolute', bottom: '40px', left: '50%', transform: 'translateX(-50%)', zIndex: 2, opacity: 0.5 }}>
-          <div style={{ width: '1px', height: '60px', background: 'white', margin: '0 auto' }}></div>
-          <span style={{ fontSize: '0.75rem', letterSpacing: '0.2em', marginTop: '10px', display: 'block' }}>SCROLL</span>
+
+        <div className="home-scroll-indicator" aria-hidden="true">
+          <div className="home-scroll-line" />
+          <span>SCROLL</span>
         </div>
       </section>
 
-      {/* 2. Technical Expertise - Cambridge Style Philosophy Grid */}
       <section className="section bg-gray">
         <div className="container">
-          <SectionHeader 
-            eyebrow="TECHNICAL EXCELLENCE" 
-            title="숫자로 증명하는 압도적 기술력" 
-            description="캠브리지 필터의 정밀 엔지니어링 정신을 계승하여, 에코가드는 오직 성능으로만 말합니다." 
+          <SectionHeader
+            eyebrow="TECHNICAL EXCELLENCE"
+            title="숫자로 증명하는 압도적 기술력"
+            description="캠브리지 필터의 정밀 엔지니어링 정신을 계승하여, 에코가드는 오직 성능으로만 말합니다."
           />
+
           <div className="philosophy-grid">
-            {[
-              { num: "99.999%", title: "ULPA Performance", desc: "0.1μm 입자까지 완벽하게 제어하는 초고성능 여과 기술" },
-              { num: "35% Lower", title: "Energy Efficient", desc: "독자적인 저압손 설계를 통한 송풍기 전력 소모 혁신적 절감" },
-              { num: "ISO Class 1", title: "Cleanliness Certified", desc: "최첨단 반도체 공정에 적합한 세계 최고 수준의 청정도 보장" }
-            ].map((item, idx) => (
-              <div key={idx} className="philosophy-item">
-                <span className="philosophy-number" style={{ fontSize: '2.5rem', marginBottom: '10px' }}>{item.num}</span>
-                <h3 className="heading-3" style={{ color: 'var(--color-navy-900)' }}>{item.title}</h3>
-                <p className="body-text" style={{ fontSize: '0.95rem' }}>{item.desc}</p>
-              </div>
+            {strengths.map((item) => (
+              <article key={item.title} className="philosophy-item home-philosophy-item">
+                <span className="philosophy-number home-philosophy-number">{item.num}</span>
+                <h3 className="heading-3">{item.title}</h3>
+                <p className="body-text">{item.desc}</p>
+              </article>
             ))}
           </div>
         </div>
       </section>
 
-      {/* 3. Core Business Areas - Large Scale Visuals */}
       <section className="section container">
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '40px', alignItems: 'center', marginBottom: '100px' }}>
-          <div>
-            <span className="section-eyebrow" style={{ color: 'var(--color-blue-600)' }}>SEMICONDUCTOR & PHARMA</span>
-            <h2 className="heading-2" style={{ fontSize: '2.5rem' }}>고청정 산업의 핵심 파트너</h2>
-            <p className="body-text" style={{ marginBottom: '32px' }}>
-              미세한 오염 물질 하나가 수조 원의 손실로 이어지는 반도체와 제약 공정. 
+        <div className="home-split-grid">
+          <div className="home-split-text">
+            <span className="section-eyebrow home-split-eyebrow">SEMICONDUCTOR & PHARMA</span>
+            <h2 className="heading-2 home-split-heading">고청정 산업의 핵심 파트너</h2>
+            <p className="body-text">
+              미세한 오염 물질 하나가 수조 원의 손실로 이어지는 반도체와 제약 공정.
               에코가드는 완벽한 기밀 유지와 케미컬 제거 기술로 가장 안전한 생산 환경을 구축합니다.
             </p>
-            <ul style={{ marginBottom: '40px' }}>
-              {['반도체/디스플레이 클린룸', '제약/바이오 무균실', '병원 음압 병동 시스템'].map(item => (
-                <li key={item} style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '12px', fontWeight: 600 }}>
-                  <span style={{ color: 'var(--color-blue-600)' }}>✓</span> {item}
+
+            <ul className="home-check-list" aria-label="적용 분야">
+              {[
+                "반도체/디스플레이 클린룸",
+                "제약/바이오 무균실",
+                "병원 음압 병동 시스템"
+              ].map((item) => (
+                <li key={item}>
+                  <span className="check-mark" aria-hidden="true">
+                    ✓
+                  </span>
+                  <span>{item}</span>
                 </li>
               ))}
             </ul>
-            <Link to="/products" className="text-link">솔루션 상세 보기</Link>
+
+            <Link to="/products" className="text-link">
+              솔루션 상세 보기
+            </Link>
           </div>
-          <div style={{ borderRadius: 'var(--radius-md)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)' }}>
-            <img 
-              src="https://images.unsplash.com/photo-1581092160562-40aa08e78837?auto=format&fit=crop&w=1200&q=80" 
-              alt="Cleanroom Technology" 
-              style={{ width: '100%', height: '500px', objectFit: 'cover' }}
+
+          <div className="home-split-image">
+            <img
+              src="https://images.unsplash.com/photo-1581092160562-40aa08e78837?auto=format&fit=crop&w=1200&q=80"
+              alt="반도체 클린룸 공정"
+              className="home-split-image-el"
+              loading="lazy"
             />
           </div>
         </div>
 
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '40px', alignItems: 'center' }}>
-          <div style={{ borderRadius: 'var(--radius-md)', overflow: 'hidden', boxShadow: 'var(--shadow-lg)', order: 2 }}>
-            <img 
-              src="https://images.unsplash.com/photo-1473862170180-84427c485aca?q=80&w=2670&auto=format&fit=crop" 
-              alt="Modern Airport Infrastructure Ventilation" 
-              style={{ width: '100%', height: '500px', objectFit: 'cover' }}
+        <div className="home-split-grid home-split-grid-reverse">
+          <div className="home-split-image home-split-image-right">
+            <img
+              src="https://images.unsplash.com/photo-1473862170180-84427c485aca?q=80&w=2670&auto=format&fit=crop"
+              alt="대형 공항 환기 인프라"
+              className="home-split-image-el"
+              loading="lazy"
             />
           </div>
-          <div style={{ order: 1 }}>
-            <span className="section-eyebrow" style={{ color: 'var(--color-blue-600)' }}>PUBLIC INFRASTRUCTURE</span>
-            <h2 className="heading-2" style={{ fontSize: '2.5rem' }}>대형 인프라 공조의 표준</h2>
-            <p className="body-text" style={{ marginBottom: '32px' }}>
-              인천공항 등 대규모 유동인구가 발생하는 공공시설의 실내 공기질은 에코가드가 책임집니다. 
+
+          <div className="home-split-text home-split-text-left">
+            <span className="section-eyebrow home-split-eyebrow">PUBLIC INFRASTRUCTURE</span>
+            <h2 className="heading-2 home-split-heading">대형 인프라 공조의 표준</h2>
+            <p className="body-text">
+              인천공항 등 대규모 유동인구가 발생하는 공공시설의 실내 공기질은 에코가드가 책임집니다.
               에너지 효율을 극대화한 대형 프리/미디움 필터 라인업을 통해 쾌적한 환경을 선사합니다.
             </p>
-            <Link to="/products" className="text-link">공조 시스템 보기</Link>
+            <Link to="/products" className="text-link">
+              공조 시스템 보기
+            </Link>
           </div>
         </div>
       </section>
 
-      {/* 4. Global Vision CTA (Cambridge Dark Style) */}
-      <section className="section" style={{ backgroundColor: 'var(--color-navy-900)', color: 'white', textAlign: 'center' }}>
-        <div className="container">
-          <h2 className="heading-2" style={{ color: 'white', fontSize: '3rem', marginBottom: '24px' }}>가장 정밀한 공기로,<br />산업의 내일을 설계합니다.</h2>
-          <p className="body-text" style={{ color: 'rgba(255,255,255,0.6)', maxWidth: '700px', margin: '0 auto 48px', fontSize: '1.2rem' }}>
-            에코가드의 기술 지원 팀은 귀사의 공조 설비 효율을 분석하여<br /> 
+      <section className="section home-cta-section">
+        <div className="container home-cta-container">
+          <h2 className="heading-2 home-cta-title">
+            가장 정밀한 공기로,
+            <br />
+            산업의 내일을 설계합니다.
+          </h2>
+          <p className="body-text home-cta-desc">
+            에코가드의 기술 지원 팀은 귀사의 공조 설비 효율을 분석하여
+            <br className="desktop-only" />
             최적의 유지보수 플랜을 제안해 드립니다.
           </p>
-          <div style={{ display: 'flex', gap: '16px', justifyContent: 'center' }}>
-            <Link to="/inquiry" className="btn btn-primary" style={{ padding: '20px 60px' }}>지금 견적 문의하기</Link>
+          <div className="home-cta-actions">
+            <Link to="/inquiry" className="btn btn-primary">
+              지금 견적 문의하기
+            </Link>
           </div>
         </div>
       </section>

--- a/src/pages/InquiryPage.jsx
+++ b/src/pages/InquiryPage.jsx
@@ -1,98 +1,102 @@
-import React, { useState } from 'react';
-import PageHero from '../components/common/PageHero';
-import SectionHeader from '../components/common/SectionHeader';
+import React, { useState } from "react";
+import PageHero from "../components/common/PageHero";
+import SectionHeader from "../components/common/SectionHeader";
 
 const InquiryPage = () => {
   const [formData, setFormData] = useState({
-    name: '',
-    company: '',
-    phone: '',
-    email: '',
-    message: '',
-    agree: false,
+    name: "",
+    company: "",
+    phone: "",
+    email: "",
+    message: "",
+    agree: false
   });
 
-  const handleChange = (e) => {
-    const { name, value, type, checked } = e.target;
-    setFormData(prev => ({
+  const handleChange = (event) => {
+    const { name, value, type, checked } = event.target;
+    setFormData((prev) => ({
       ...prev,
-      [name]: type === 'checkbox' ? checked : value
+      [name]: type === "checkbox" ? checked : value
     }));
   };
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
     if (!formData.agree) {
-      alert('개인정보 수집 및 이용에 동의해주세요.');
+      alert("개인정보 수집 및 이용에 동의해주세요.");
       return;
     }
-    // API Call Simulate
-    console.log('Sending Inquiry:', formData);
-    alert('문의가 접수되었습니다. 담당자가 확인 후 연락드리겠습니다.');
-  };
 
-  const inputStyle = {
-    width: '100%',
-    padding: '16px',
-    border: '1px solid var(--color-gray-200)',
-    borderRadius: 'var(--radius-sm)',
-    fontSize: '1rem',
-    outline: 'none',
-    marginBottom: '24px'
+    // 추후 서버 API 연결 예정
+    console.log("Sending inquiry:", formData);
+    alert("문의가 접수되었습니다. 담당자가 확인 후 연락드리겠습니다.");
   };
 
   return (
-    <div>
-      <PageHero 
-        title="Get a Quote" 
+    <div className="inquiry-page">
+      <PageHero
+        title="Get a Quote"
         subtitle="프로젝트 규모와 요구사항을 남겨주시면 전문가가 상세한 견적을 제안드립니다."
         bgImage="https://images.unsplash.com/photo-1542744173-8e7e53415bb0?auto=format&fit=crop&w=1200&q=80"
+        imageAlt="회의실에서 상담하는 기업 담당자"
       />
 
       <section className="section container">
-        <SectionHeader 
-          eyebrow="CONTACT US" 
-          title="견적 문의" 
-          description="빠른 시일 내에 이메일 또는 유선으로 회신 드리겠습니다." 
+        <SectionHeader
+          eyebrow="CONTACT US"
+          title="견적 문의"
+          description="빠른 시일 내에 이메일 또는 유선으로 회신 드리겠습니다."
         />
 
-        <div style={{ maxWidth: '800px', margin: '0 auto', background: 'var(--color-navy-50)', padding: '60px', borderRadius: 'var(--radius-md)' }}>
-          <form onSubmit={handleSubmit}>
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px' }}>
-              <div>
-                <label className="body-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>이름 *</label>
-                <input type="text" name="name" required style={inputStyle} onChange={handleChange} />
+        <div className="inquiry-form-wrap">
+          <form className="inquiry-form" onSubmit={handleSubmit}>
+            <div className="inquiry-row">
+              <div className="form-field">
+                <label htmlFor="name">이름 *</label>
+                <input id="name" type="text" name="name" required className="form-input" onChange={handleChange} />
               </div>
-              <div>
-                <label className="body-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>회사명</label>
-                <input type="text" name="company" style={inputStyle} onChange={handleChange} />
-              </div>
-            </div>
-
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '24px' }}>
-              <div>
-                <label className="body-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>연락처 *</label>
-                <input type="tel" name="phone" required style={inputStyle} onChange={handleChange} />
-              </div>
-              <div>
-                <label className="body-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>이메일 *</label>
-                <input type="email" name="email" required style={inputStyle} onChange={handleChange} />
+              <div className="form-field">
+                <label htmlFor="company">회사명</label>
+                <input id="company" type="text" name="company" className="form-input" onChange={handleChange} />
               </div>
             </div>
 
-            <div>
-              <label className="body-text" style={{ display: 'block', marginBottom: '8px', fontWeight: 600 }}>문의내용 *</label>
-              <textarea name="message" required rows="5" style={{ ...inputStyle, resize: 'vertical' }} onChange={handleChange}></textarea>
+            <div className="inquiry-row">
+              <div className="form-field">
+                <label htmlFor="phone">연락처 *</label>
+                <input id="phone" type="tel" name="phone" required className="form-input" onChange={handleChange} />
+              </div>
+              <div className="form-field">
+                <label htmlFor="email">이메일 *</label>
+                <input id="email" type="email" name="email" required className="form-input" onChange={handleChange} />
+              </div>
             </div>
 
-            <div style={{ display: 'flex', alignItems: 'center', marginBottom: '32px' }}>
-              <input type="checkbox" name="agree" id="agree" checked={formData.agree} onChange={handleChange} style={{ width: '20px', height: '20px', marginRight: '12px' }} />
-              <label htmlFor="agree" className="body-text" style={{ fontSize: '0.9rem' }}>
-                [필수] 개인정보 수집 및 이용에 동의합니다.
-              </label>
+            <div className="form-field">
+              <label htmlFor="message">문의내용 *</label>
+              <textarea
+                id="message"
+                name="message"
+                required
+                rows="6"
+                className="form-input form-textarea"
+                onChange={handleChange}
+              />
             </div>
 
-            <button type="submit" className="btn btn-primary" style={{ width: '100%', padding: '20px', fontSize: '1.1rem' }}>
+            <div className="inquiry-consent">
+              <input
+                id="agree"
+                type="checkbox"
+                name="agree"
+                checked={formData.agree}
+                onChange={handleChange}
+              />
+              <label htmlFor="agree">[필수] 개인정보 수집 및 이용에 동의합니다.</label>
+            </div>
+
+            <button type="submit" className="btn btn-primary inquiry-submit">
               문의 접수하기
             </button>
           </form>

--- a/src/pages/NoticeDetailPage.jsx
+++ b/src/pages/NoticeDetailPage.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
-import PageHero from '../components/common/PageHero';
-import { fetchNoticeById } from '../services/api/notices';
+import React, { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import PageHero from "../components/common/PageHero";
+import { fetchNoticeById } from "../services/api/notices";
 
 const NoticeDetailPage = () => {
   const { noticeId } = useParams();
@@ -20,12 +20,13 @@ const NoticeDetailPage = () => {
         setIsLoading(false);
       }
     }
+
     loadNotice();
   }, [noticeId]);
 
   if (isLoading) {
     return (
-      <div className="container section" style={{ textAlign: 'center' }}>
+      <div className="container section notice-state-wrap">
         <p className="body-text">공지사항을 불러오는 중입니다...</p>
       </div>
     );
@@ -33,25 +34,28 @@ const NoticeDetailPage = () => {
 
   if (!notice) {
     return (
-      <div className="container section" style={{ textAlign: 'center' }}>
+      <div className="container section notice-state-wrap">
         <h2 className="heading-2">존재하지 않는 게시글입니다.</h2>
-        <Link to="/notices" className="btn btn-primary" style={{ marginTop: '24px' }}>목록으로 돌아가기</Link>
+        <Link to="/notices" className="btn btn-primary notice-state-button">
+          목록으로 돌아가기
+        </Link>
       </div>
     );
   }
 
   return (
-    <div>
-      <PageHero 
-        title="Notice & News" 
+    <div className="notice-detail-page">
+      <PageHero
+        title="Notice & News"
         subtitle="에코가드의 최신 소식을 상세히 확인하세요."
         bgImage="https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&w=1200&q=80"
+        imageAlt="공지사항 상세 페이지"
       />
 
       <section className="section container">
         <article className="notice-content-area">
           <header className="notice-header">
-            <span className="notice-badge" style={{ marginBottom: '16px' }}>에코가드 공식 공지</span>
+            <span className="notice-badge notice-badge-header">에코가드 공식 공지</span>
             <h1 className="heading-1">{notice.title}</h1>
             <div className="notice-meta">
               <span>작성일: {notice.publishedAt}</span>
@@ -61,23 +65,26 @@ const NoticeDetailPage = () => {
           </header>
 
           <div className="notice-body">
-            {/* Split content by newlines to render as paragraphs for better readability */}
-            {notice.content.split('\n').map((line, idx) => (
-              <p key={idx} style={{ marginBottom: '24px' }}>{line}</p>
+            {notice.content.split("\n").map((line, index) => (
+              <p key={`${notice.id}-${index}`}>{line}</p>
             ))}
           </div>
 
           <footer className="notice-footer">
-            <button 
-              className="btn btn-outline" 
-              onClick={() => navigate('/notices')}
-              style={{ padding: '12px 32px' }}
+            <button
+              type="button"
+              className="btn btn-outline"
+              onClick={() => navigate("/notices")}
             >
               목록으로
             </button>
-            <div style={{ display: 'flex', gap: '12px' }}>
-              <button className="btn btn-outline" disabled style={{ opacity: 0.5 }}>이전글</button>
-              <button className="btn btn-outline" disabled style={{ opacity: 0.5 }}>다음글</button>
+            <div className="notice-footer-actions" aria-label="이전 다음 게시글 버튼">
+              <button type="button" className="btn btn-outline" disabled>
+                이전글
+              </button>
+              <button type="button" className="btn btn-outline" disabled>
+                다음글
+              </button>
             </div>
           </footer>
         </article>

--- a/src/pages/NoticeListPage.jsx
+++ b/src/pages/NoticeListPage.jsx
@@ -1,14 +1,13 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import PageHero from '../components/common/PageHero';
-import SectionHeader from '../components/common/SectionHeader';
-import { fetchNoticeList } from '../services/api/notices';
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import PageHero from "../components/common/PageHero";
+import { fetchNoticeList } from "../services/api/notices";
 
 const NoticeListPage = () => {
   const navigate = useNavigate();
   const [notices, setNotices] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {
     async function loadNotices() {
@@ -21,102 +20,95 @@ const NoticeListPage = () => {
         setIsLoading(false);
       }
     }
+
     loadNotices();
   }, []);
 
-  const filteredNotices = notices.filter(notice => 
-    notice.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    notice.summary.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+  const filteredNotices = notices.filter((notice) => {
+    const keyword = searchTerm.toLowerCase();
+    return (
+      notice.title.toLowerCase().includes(keyword) ||
+      notice.summary.toLowerCase().includes(keyword)
+    );
+  });
 
   return (
-    <div>
-      <PageHero 
-        title="Notice & News" 
+    <div className="notice-list-page">
+      <PageHero
+        title="Notice & News"
         subtitle="에코가드의 최신 기술 소식과 공지사항을 전해드립니다."
         bgImage="https://images.unsplash.com/photo-1497366216548-37526070297c?auto=format&fit=crop&w=1200&q=80"
+        imageAlt="기업 공지사항 관리 화면"
       />
 
       <section className="section container">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: '40px', flexWrap: 'wrap', gap: '20px' }}>
+        <header className="notice-list-toolbar">
           <div>
             <span className="section-eyebrow">LATEST UPDATES</span>
-            <h2 className="heading-2" style={{ marginBottom: 0 }}>전체 공지사항</h2>
+            <h2 className="heading-2 notice-list-title">전체 공지사항</h2>
           </div>
-          
-          <div style={{ position: 'relative', maxWidth: '300px', width: '100%' }}>
-            <input 
-              type="text" 
-              placeholder="검색어를 입력하세요" 
+
+          <div className="notice-search-wrap">
+            <input
+              type="text"
+              placeholder="검색어를 입력하세요"
               value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              style={{
-                width: '100%',
-                padding: '12px 16px',
-                paddingLeft: '40px',
-                border: '1px solid var(--color-gray-200)',
-                borderRadius: 'var(--radius-sm)',
-                outline: 'none',
-                fontSize: '0.95rem'
-              }}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              className="notice-search-input"
+              aria-label="공지사항 검색"
             />
-            <span style={{ position: 'absolute', left: '12px', top: '50%', transform: 'translateY(-50%)', opacity: 0.4 }}>
-              🔍
+            <span className="notice-search-icon" aria-hidden="true">
+              검색
             </span>
           </div>
-        </div>
+        </header>
 
         {isLoading ? (
-          <div style={{ textAlign: 'center', padding: '100px 0', color: 'var(--color-gray-400)' }}>
-            데이터를 불러오는 중입니다...
-          </div>
+          <div className="notice-loading">데이터를 불러오는 중입니다...</div>
         ) : filteredNotices.length > 0 ? (
-          <div style={{ overflowX: 'auto' }}>
+          <div className="notice-table-wrap">
             <table className="notice-table">
               <thead>
                 <tr>
-                  <th style={{ width: '80px', textAlign: 'center' }}>No.</th>
-                  <th style={{ width: '120px', textAlign: 'center' }}>구분</th>
+                  <th className="notice-col-number">No.</th>
+                  <th className="notice-col-type">구분</th>
                   <th>제목</th>
-                  <th style={{ width: '150px', textAlign: 'center' }}>작성일</th>
+                  <th className="notice-col-date">작성일</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredNotices.map((notice, index) => (
-                  <tr key={notice.id} className="notice-row" onClick={() => navigate(`/notices/${notice.id}`)}>
-                    <td style={{ textAlign: 'center', color: 'var(--color-gray-400)' }}>{filteredNotices.length - index}</td>
-                    <td style={{ textAlign: 'center' }}>
-                      <span className={`notice-badge ${index === 0 ? 'urgent' : ''}`}>
-                        {index === 0 ? '중요' : '공지'}
+                  <tr
+                    key={notice.id}
+                    className="notice-row"
+                    onClick={() => navigate(`/notices/${notice.id}`)}
+                  >
+                    <td className="notice-number-cell">{filteredNotices.length - index}</td>
+                    <td className="notice-type-cell">
+                      <span className={`notice-badge ${index === 0 ? "urgent" : ""}`}>
+                        {index === 0 ? "중요" : "공지"}
                       </span>
                     </td>
                     <td className="notice-title-cell">
                       {notice.title}
-                      <p style={{ fontWeight: 400, fontSize: '0.9rem', color: 'var(--color-gray-400)', marginTop: '4px' }}>
-                        {notice.summary}
-                      </p>
+                      <p className="notice-summary-cell">{notice.summary}</p>
                     </td>
-                    <td className="notice-date-cell" style={{ textAlign: 'center' }}>
-                      {notice.publishedAt}
-                    </td>
+                    <td className="notice-date-cell">{notice.publishedAt}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
         ) : (
-          <div style={{ textAlign: 'center', padding: '100px 0', background: 'var(--color-navy-50)', borderRadius: 'var(--radius-md)' }}>
+          <div className="notice-empty">
             <p className="body-text">검색 결과가 없습니다.</p>
           </div>
         )}
 
-        {/* Mock Pagination */}
-        <div style={{ display: 'flex', justifyContent: 'center', gap: '8px', marginTop: '60px' }}>
-          {[1].map(page => (
-            <button key={page} className="btn btn-outline" style={{ padding: '8px 16px', minWidth: '40px', background: 'var(--color-navy-900)', color: 'white' }}>
-              {page}
-            </button>
-          ))}
+        <div className="notice-pagination" aria-label="페이지네이션">
+          <button type="button" className="btn btn-outline notice-page-button" aria-current="page">
+            1
+          </button>
         </div>
       </section>
     </div>

--- a/src/pages/ProductCategoryPage.jsx
+++ b/src/pages/ProductCategoryPage.jsx
@@ -1,77 +1,72 @@
-import React, { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
-import PageHero from '../components/common/PageHero';
-import EmptyState from '../components/common/EmptyState';
-import { categories, getCategoryById } from '../data/categories';
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import PageHero from "../components/common/PageHero";
+import EmptyState from "../components/common/EmptyState";
+import { categories, getCategoryById } from "../data/categories";
 
 const ProductCategoryPage = () => {
   const { categorySlug } = useParams();
   const [category, setCategory] = useState(null);
-  const [products, setProducts] = useState([]); // Currently empty, mimicking no DB connection yet
+  const [products, setProducts] = useState([]);
 
   useEffect(() => {
-    // 1. Fetch category metadata (Simulated)
     const currentCategory = getCategoryById(categorySlug);
     setCategory(currentCategory);
-    
-    // 2. Fetch products for this category (Simulated API call)
-    // In the future, this will be: api.get(`/products?category=${categorySlug}`)
-    setProducts([]); // Intentionally empty as per requirement
+
+    // 향후 어드민 등록 데이터 연동 시 API 조회로 교체
+    setProducts([]);
   }, [categorySlug]);
 
   if (!category) {
     return (
-      <div className="container section" style={{ textAlign: 'center' }}>
-        <h2>존재하지 않는 카테고리입니다.</h2>
-        <Link to="/products" className="btn btn-primary" style={{ marginTop: '20px' }}>목록으로 돌아가기</Link>
+      <div className="container section category-state-wrap">
+        <h2 className="heading-2">존재하지 않는 카테고리입니다.</h2>
+        <Link to="/products" className="btn btn-primary category-state-button">
+          목록으로 돌아가기
+        </Link>
       </div>
     );
   }
 
   return (
-    <div>
-      <PageHero 
-        title={category.name} 
+    <div className="product-category-page">
+      <PageHero
+        title={category.name}
         subtitle={category.description}
         bgImage="https://images.unsplash.com/photo-1555529733-0e670560f7e1?q=80&w=2574&auto=format&fit=crop"
+        imageAlt={`${category.name} 카테고리 대표 이미지`}
       />
-      
+
       <section className="section container">
-        {/* Breadcrumb & Navigation (Optional for UX) */}
-        <div style={{ marginBottom: '40px', display: 'flex', gap: '12px', flexWrap: 'wrap' }}>
-          {categories.map(c => (
-            <Link 
-              key={c.id} 
-              to={`/products/${c.id}`}
-              className={`btn btn-outline ${c.id === categorySlug ? 'active' : ''}`}
-              style={{ 
-                padding: '8px 16px', 
-                fontSize: '0.9rem',
-                background: c.id === categorySlug ? 'var(--color-navy-900)' : 'white',
-                color: c.id === categorySlug ? 'white' : 'var(--color-navy-900)',
-                borderColor: c.id === categorySlug ? 'var(--color-navy-900)' : 'var(--color-gray-200)'
-              }}
-            >
-              {c.name}
-            </Link>
-          ))}
+        <div className="product-category-tabs" aria-label="제품 카테고리 탭">
+          {categories.map((item) => {
+            const isActive = item.id === categorySlug;
+            return (
+              <Link
+                key={item.id}
+                to={`/products/${item.id}`}
+                className={`btn btn-outline product-category-tab ${isActive ? "active" : ""}`}
+              >
+                {item.name}
+              </Link>
+            );
+          })}
         </div>
 
-        {/* Dynamic Content Area */}
         {products.length > 0 ? (
           <div className="product-grid">
-            {/* Future Product Card Component will go here */}
-            {products.map(product => (
+            {products.map((product) => (
               <div key={product.id}>{product.name}</div>
             ))}
           </div>
         ) : (
-          /* The Core Requirement: Empty State UI */
-          <EmptyState 
+          <EmptyState
             title="등록된 제품이 없습니다"
             message={`현재 '${category.name}' 카테고리에 등록된 제품 정보가 준비 중입니다. 관리자 페이지에서 제품을 등록하면 이곳에 표시됩니다.`}
             actionText="제품 문의하기"
-            onAction={() => window.location.href = '/inquiry'}
+            onAction={() => {
+              window.location.href = "/inquiry";
+            }}
           />
         )}
       </section>

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1,17 +1,18 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import PageHero from '../components/common/PageHero';
-import { categories } from '../data/categories';
+import React from "react";
+import { Link } from "react-router-dom";
+import PageHero from "../components/common/PageHero";
+import { categories } from "../data/categories";
 
 const ProductsPage = () => {
   return (
-    <div>
-      <PageHero 
-        title="Products & Services" 
+    <div className="products-page">
+      <PageHero
+        title="Products & Services"
         subtitle="공항, 반도체, 제약 산업을 위한 고성능 공조 필터 솔루션"
         bgImage="https://images.unsplash.com/photo-1555529733-0e670560f7e1?q=80&w=2574&auto=format&fit=crop"
+        imageAlt="산업용 필터 장비"
       />
-      
+
       <section className="section container">
         <div className="section-header">
           <span className="section-eyebrow">Product Lineup</span>
@@ -19,39 +20,18 @@ const ProductsPage = () => {
           <p>고객사의 환경에 최적화된 다양한 필터 라인업을 확인하세요.</p>
         </div>
 
-        <div className="card-grid">
+        <div className="card-grid product-card-grid">
           {categories.map((category) => (
             <Link to={`/products/${category.id}`} key={category.id} className="product-category-card">
-              <div style={{
-                padding: '40px 32px',
-                border: '1px solid var(--color-gray-200)',
-                borderRadius: 'var(--radius-md)',
-                transition: 'all 0.3s ease',
-                height: '100%',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-between',
-                background: 'white',
-                boxShadow: 'var(--shadow-sm)'
-              }}
-              onMouseEnter={(e) => {
-                e.currentTarget.style.transform = 'translateY(-5px)';
-                e.currentTarget.style.borderColor = 'var(--color-blue-600)';
-                e.currentTarget.style.boxShadow = 'var(--shadow-lg)';
-              }}
-              onMouseLeave={(e) => {
-                e.currentTarget.style.transform = 'translateY(0)';
-                e.currentTarget.style.borderColor = 'var(--color-gray-200)';
-                e.currentTarget.style.boxShadow = 'var(--shadow-sm)';
-              }}
-              >
+              <div className="product-category-card-body">
                 <div>
-                  <h3 className="heading-3" style={{ color: 'var(--color-blue-600)' }}>{category.name}</h3>
+                  <h3 className="heading-3 product-category-title">{category.name}</h3>
                   <p className="body-text">{category.description}</p>
                 </div>
-                <div style={{ marginTop: '24px', fontWeight: 600, color: 'var(--color-navy-900)', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                  View Products 
-                  <span style={{ fontSize: '1.2em' }}>→</span>
+
+                <div className="product-category-link">
+                  View Products
+                  <span aria-hidden="true">→</span>
                 </div>
               </div>
             </Link>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,37 +1,42 @@
 :root {
-  /* Brand Colors - Engineering Purity */
-  --color-navy-900: #0f172a; /* Main Text, Footer, Heavy BG */
+  --color-navy-900: #0f172a;
   --color-navy-800: #1e293b;
-  --color-navy-50: #f8fafc;  /* Subtle BG */
-  
-  --color-blue-600: #0066ff; /* Primary Brand Color */
-  --color-blue-700: #0052cc; /* Hover State */
-  --color-cyan-500: #06b6d4; /* Accent: Clean Air */
-  
+  --color-navy-50: #f8fafc;
+
+  --color-blue-600: #0066ff;
+  --color-blue-700: #0052cc;
+  --color-cyan-500: #06b6d4;
+
   --color-white: #ffffff;
   --color-gray-100: #f1f5f9;
-  --color-gray-200: #e2e8f0; /* Borders */
-  --color-gray-400: #94a3b8; /* Subtext */
-  --color-gray-600: #475569; /* Body Text */
+  --color-gray-200: #e2e8f0;
+  --color-gray-400: #94a3b8;
+  --color-gray-600: #475569;
 
-  /* Typography */
-  --font-main: 'Pretendard Variable', 'Inter', -apple-system, sans-serif;
-  --heading-weight: 700;
-  
-  /* Layout */
+  --font-main: "Pretendard Variable", "Inter", -apple-system, sans-serif;
+
   --container-width: 1280px;
   --header-height: 80px;
-  
-  /* Effects */
+
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --radius-sm: 4px;
-  --radius-md: 8px; /* Industrial rounded, not too soft */
+  --radius-md: 8px;
+  --transition: 0.24s ease;
 }
 
-/* Reset & Base */
-* { box-sizing: border-box; margin: 0; padding: 0; }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body,
+#root {
+  min-height: 100%;
+}
 
 body {
   font-family: var(--font-main);
@@ -39,33 +44,234 @@ body {
   background-color: var(--color-white);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
 }
 
-a { text-decoration: none; color: inherit; transition: 0.2s; }
-ul { list-style: none; }
-img { max-width: 100%; display: block; }
-button { font-family: inherit; cursor: pointer; border: none; background: none; }
+a {
+  text-decoration: none;
+  color: inherit;
+}
 
-/* Utilities */
+ul {
+  list-style: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+button {
+  font-family: inherit;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
 .container {
   max-width: var(--container-width);
   margin: 0 auto;
   padding: 0 24px;
 }
 
-.section { padding: 100px 0; }
-.bg-gray { background-color: var(--color-navy-50); }
+.section {
+  padding: 100px 0;
+}
 
-/* Typography Hierarchy */
-h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
+.bg-gray {
+  background-color: var(--color-navy-50);
+}
 
-.display-1 { font-size: 3.5rem; font-weight: 800; line-height: 1.2; }
-.heading-1 { font-size: 2.5rem; font-weight: 700; margin-bottom: 1.5rem; }
-.heading-2 { font-size: 2rem; font-weight: 700; margin-bottom: 1rem; }
-.heading-3 { font-size: 1.5rem; font-weight: 600; margin-bottom: 0.75rem; }
-.body-text { font-size: 1.05rem; color: var(--color-gray-600); }
+.site-shell {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
 
-/* Component: Buttons */
+.site-main {
+  flex: 1;
+  padding-top: var(--header-height);
+}
+
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  height: var(--header-height);
+  background: rgb(255 255 255 / 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid transparent;
+  transition: var(--transition);
+}
+
+.site-header.is-scrolled {
+  background: rgb(255 255 255 / 0.96);
+  border-bottom-color: var(--color-gray-200);
+}
+
+.header-inner {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.brand {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--color-navy-900);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  letter-spacing: 0.02em;
+  z-index: 1001;
+}
+
+.brand-mark {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  background: var(--color-blue-600);
+}
+
+.menu-toggle {
+  display: none;
+  width: 44px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 5px;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 8px;
+  z-index: 1001;
+}
+
+.menu-toggle span {
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--color-navy-900);
+  transition: var(--transition);
+}
+
+.menu-toggle.is-open span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.menu-toggle.is-open span:nth-child(2) {
+  opacity: 0;
+}
+
+.menu-toggle.is-open span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+.global-nav ul {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+}
+
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-gray-600);
+  transition: color var(--transition);
+}
+
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--color-blue-600);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--transition);
+}
+
+.nav-link:hover,
+.nav-link.active {
+  color: var(--color-blue-600);
+}
+
+.nav-link:hover::after,
+.nav-link.active::after {
+  transform: scaleX(1);
+}
+
+.site-footer {
+  background: var(--color-navy-900);
+  color: rgb(255 255 255 / 0.86);
+  padding: 60px 0;
+}
+
+.footer-brand {
+  margin-bottom: 24px;
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: var(--color-white);
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  font-size: 0.92rem;
+}
+
+.footer-copyright {
+  text-align: right;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  letter-spacing: -0.02em;
+  color: var(--color-navy-900);
+}
+
+.display-1 {
+  font-size: 3.5rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
+.heading-1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.heading-2 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.heading-3 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.body-text {
+  font-size: 1.05rem;
+  color: var(--color-gray-600);
+}
+
 .btn {
   display: inline-flex;
   align-items: center;
@@ -74,28 +280,59 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
   font-weight: 600;
   font-size: 1rem;
   border-radius: var(--radius-sm);
-  transition: all 0.2s ease;
+  border: 1px solid transparent;
+  transition: transform var(--transition), background-color var(--transition), border-color var(--transition), color var(--transition);
 }
 
 .btn-primary {
   background: var(--color-blue-600);
-  color: white;
+  color: var(--color-white);
 }
-.btn-primary:hover { background: var(--color-blue-700); transform: translateY(-1px); }
+
+.btn-primary:hover {
+  background: var(--color-blue-700);
+  transform: translateY(-1px);
+}
 
 .btn-outline {
-  border: 1px solid var(--color-gray-200);
+  border-color: var(--color-gray-200);
   color: var(--color-navy-900);
-  background: white;
+  background: var(--color-white);
 }
-.btn-outline:hover { border-color: var(--color-blue-600); color: var(--color-blue-600); }
 
-/* Component: Section Header */
+.btn-outline:hover {
+  border-color: var(--color-blue-600);
+  color: var(--color-blue-600);
+}
+
+.btn-ghost-light {
+  border-color: rgb(255 255 255 / 0.35);
+  color: var(--color-white);
+  background: transparent;
+}
+
+.btn-ghost-light:hover {
+  border-color: rgb(255 255 255 / 0.7);
+  background: rgb(255 255 255 / 0.08);
+}
+
+.btn-outline-light {
+  border-color: rgb(255 255 255 / 0.4);
+  color: var(--color-white);
+  background: transparent;
+}
+
+.btn-outline-light:hover {
+  border-color: rgb(255 255 255 / 0.85);
+  color: var(--color-white);
+}
+
 .section-header {
   text-align: center;
   max-width: 700px;
   margin: 0 auto 60px;
 }
+
 .section-eyebrow {
   display: block;
   color: var(--color-cyan-500);
@@ -105,22 +342,591 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
   font-size: 0.875rem;
   margin-bottom: 12px;
 }
-.section-header h2 { font-size: 2.25rem; margin-bottom: 16px; }
-.section-header p { font-size: 1.125rem; color: var(--color-gray-600); }
 
-/* Specific Components */
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 32px;
+.section-header h2 {
+  font-size: 2.25rem;
+  margin-bottom: 16px;
 }
 
-/* Notice Styles - B2B Modern */
+.section-header p,
+.section-description {
+  font-size: 1.125rem;
+  color: var(--color-gray-600);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 22px;
+  color: var(--color-blue-600);
+  font-weight: 700;
+}
+
+.text-link::after {
+  content: "→";
+  transition: transform var(--transition);
+}
+
+.text-link:hover::after {
+  transform: translateX(4px);
+}
+
+.page-hero {
+  position: relative;
+  min-height: 360px;
+  display: flex;
+  align-items: flex-end;
+  color: var(--color-white);
+  overflow: hidden;
+}
+
+.page-hero-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  filter: brightness(0.34);
+}
+
+.page-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgb(15 23 42 / 0.15) 0%, rgb(15 23 42 / 0.55) 100%);
+}
+
+.page-hero-content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  padding: 0 24px 56px;
+}
+
+.page-hero h1 {
+  color: var(--color-white);
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 10px;
+}
+
+.page-hero p {
+  max-width: 760px;
+  color: rgb(255 255 255 / 0.82);
+  font-size: 1.1rem;
+}
+
+.home-hero {
+  position: relative;
+  height: 100vh;
+  min-height: 680px;
+  display: flex;
+  align-items: center;
+  color: var(--color-white);
+  margin-top: calc(var(--header-height) * -1);
+  overflow: hidden;
+}
+
+.home-hero-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  filter: brightness(0.3);
+}
+
+.home-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgb(15 23 42 / 0.28) 0%, rgb(15 23 42 / 0.72) 100%);
+}
+
+.home-hero-content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+}
+
+.home-hero-eyebrow {
+  color: var(--color-cyan-500);
+  font-size: 1rem;
+  letter-spacing: 0.26em;
+  margin-bottom: 24px;
+}
+
+.home-hero-title {
+  margin-bottom: 28px;
+  color: var(--color-white);
+  line-height: 1.1;
+  max-width: 920px;
+}
+
+.home-hero-title span {
+  color: var(--color-blue-600);
+}
+
+.home-hero-desc {
+  max-width: 840px;
+  color: rgb(255 255 255 / 0.85);
+  margin-bottom: 42px;
+  font-weight: 300;
+}
+
+.home-hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.home-scroll-indicator {
+  position: absolute;
+  left: 50%;
+  bottom: 36px;
+  z-index: 1;
+  transform: translateX(-50%);
+  opacity: 0.56;
+  text-align: center;
+}
+
+.home-scroll-line {
+  width: 1px;
+  height: 60px;
+  margin: 0 auto;
+  background: rgb(255 255 255 / 0.7);
+}
+
+.home-scroll-indicator span {
+  display: block;
+  margin-top: 8px;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+}
+
+.philosophy-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--color-gray-200);
+  border: 1px solid var(--color-gray-200);
+}
+
+.philosophy-item {
+  background: var(--color-white);
+  padding: 56px 36px;
+  text-align: center;
+  transition: var(--transition);
+}
+
+.philosophy-item:hover {
+  background: var(--color-navy-50);
+}
+
+.philosophy-number {
+  display: block;
+  color: var(--color-blue-600);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin-bottom: 18px;
+}
+
+.home-philosophy-number {
+  font-size: 2.25rem;
+  margin-bottom: 12px;
+}
+
+.home-split-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 44px;
+  align-items: center;
+}
+
+.home-split-grid + .home-split-grid {
+  margin-top: 96px;
+}
+
+.home-split-grid-reverse .home-split-image {
+  order: 2;
+}
+
+.home-split-grid-reverse .home-split-text {
+  order: 1;
+}
+
+.home-split-heading {
+  margin-bottom: 22px;
+  font-size: 2.3rem;
+}
+
+.home-split-eyebrow {
+  color: var(--color-blue-600);
+}
+
+.home-check-list {
+  margin-top: 26px;
+}
+
+.home-check-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 10px;
+  font-weight: 600;
+  color: var(--color-navy-800);
+}
+
+.check-mark {
+  color: var(--color-blue-600);
+  line-height: 1.4;
+}
+
+.home-split-image {
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+}
+
+.home-split-image-el {
+  width: 100%;
+  height: 500px;
+  object-fit: cover;
+}
+
+.home-cta-section {
+  background: var(--color-navy-900);
+  color: var(--color-white);
+  text-align: center;
+}
+
+.home-cta-title {
+  color: var(--color-white);
+  font-size: 2.8rem;
+  margin-bottom: 22px;
+}
+
+.home-cta-desc {
+  color: rgb(255 255 255 / 0.68);
+  max-width: 740px;
+  margin: 0 auto 44px;
+}
+
+.home-cta-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.company-ceo-section {
+  background: var(--color-white);
+}
+
+.company-ceo-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 80px;
+  align-items: center;
+}
+
+.company-ceo-eyebrow {
+  color: var(--color-blue-600);
+}
+
+.company-ceo-title {
+  font-size: 2.6rem;
+  line-height: 1.3;
+  margin-bottom: 30px;
+}
+
+.company-ceo-body {
+  font-size: 1.08rem;
+  line-height: 1.8;
+}
+
+.company-ceo-body p + p {
+  margin-top: 22px;
+}
+
+.company-ceo-role {
+  font-weight: 600;
+  color: var(--color-navy-900);
+}
+
+.ceo-signature {
+  margin-top: 36px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.signature-line {
+  width: 60px;
+  height: 1px;
+  background: var(--color-navy-900);
+}
+
+.signature-text {
+  font-family: "Cormorant Garamond", serif;
+  font-size: 1.5rem;
+  font-style: italic;
+  font-weight: 600;
+  color: var(--color-navy-900);
+}
+
+.company-ceo-image-wrap {
+  position: relative;
+  min-height: 500px;
+}
+
+.company-ceo-image-bg {
+  position: absolute;
+  top: 40px;
+  left: 40px;
+  right: -40px;
+  bottom: -40px;
+  border-radius: var(--radius-md);
+  background: var(--color-navy-50);
+}
+
+.company-ceo-image {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 520px;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+  filter: grayscale(30%) contrast(1.08);
+}
+
+.history-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.history-item {
+  display: flex;
+  gap: 60px;
+  padding-bottom: 60px;
+  position: relative;
+}
+
+.history-item::before {
+  content: "";
+  position: absolute;
+  left: 110px;
+  top: 10px;
+  bottom: 0;
+  width: 1px;
+  background: var(--color-gray-200);
+}
+
+.history-item:last-child::before {
+  display: none;
+}
+
+.history-year {
+  width: 110px;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--color-navy-900);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.history-dot {
+  position: absolute;
+  left: 106px;
+  top: 10px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--color-blue-600);
+  z-index: 1;
+}
+
+.history-content {
+  padding-top: 4px;
+}
+
+.history-content h4 {
+  font-size: 1.125rem;
+  margin-bottom: 8px;
+  color: var(--color-blue-600);
+}
+
+.company-cta-section {
+  background: var(--color-navy-900);
+  color: var(--color-white);
+  text-align: center;
+}
+
+.company-cta-eyebrow {
+  color: var(--color-cyan-500);
+}
+
+.company-cta-title {
+  color: var(--color-white);
+  margin-bottom: 20px;
+}
+
+.company-cta-desc {
+  max-width: 700px;
+  margin: 0 auto 40px;
+  color: rgb(255 255 255 / 0.72);
+}
+
+.company-cta-actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.inquiry-form-wrap {
+  max-width: 860px;
+  margin: 0 auto;
+  background: var(--color-navy-50);
+  padding: 56px;
+  border-radius: var(--radius-md);
+}
+
+.inquiry-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.form-field {
+  margin-bottom: 24px;
+}
+
+.form-field label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+  color: var(--color-navy-900);
+}
+
+.form-input {
+  width: 100%;
+  padding: 14px 16px;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
+  color: var(--color-navy-800);
+  background: var(--color-white);
+  outline: none;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.form-input:focus {
+  border-color: var(--color-blue-600);
+  box-shadow: 0 0 0 3px rgb(0 102 255 / 0.12);
+}
+
+.form-textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.inquiry-consent {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 32px;
+}
+
+.inquiry-consent input {
+  margin-top: 2px;
+  width: 18px;
+  height: 18px;
+}
+
+.inquiry-consent label {
+  font-size: 0.94rem;
+  color: var(--color-gray-600);
+}
+
+.inquiry-submit {
+  width: 100%;
+  padding-top: 18px;
+  padding-bottom: 18px;
+  font-size: 1.05rem;
+}
+
+.notice-list-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 20px;
+  margin-bottom: 40px;
+  flex-wrap: wrap;
+}
+
+.notice-list-title {
+  margin-bottom: 0;
+}
+
+.notice-search-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+}
+
+.notice-search-input {
+  width: 100%;
+  padding: 12px 14px 12px 60px;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-sm);
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.notice-search-input:focus {
+  border-color: var(--color-blue-600);
+  box-shadow: 0 0 0 3px rgb(0 102 255 / 0.12);
+}
+
+.notice-search-icon {
+  position: absolute;
+  top: 50%;
+  left: 14px;
+  transform: translateY(-50%);
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--color-gray-400);
+  pointer-events: none;
+}
+
+.notice-loading,
+.notice-empty,
+.notice-state-wrap,
+.category-state-wrap {
+  text-align: center;
+}
+
+.notice-loading,
+.notice-empty {
+  padding: 96px 0;
+  color: var(--color-gray-400);
+  background: var(--color-navy-50);
+  border-radius: var(--radius-md);
+}
+
+.notice-table-wrap {
+  overflow-x: auto;
+}
+
 .notice-table {
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  margin-top: 40px;
 }
 
 .notice-table th {
@@ -135,18 +941,46 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
   letter-spacing: 0.05em;
 }
 
+.notice-col-number,
+.notice-col-type,
+.notice-col-date,
+.notice-number-cell,
+.notice-type-cell,
+.notice-date-cell {
+  text-align: center;
+}
+
+.notice-col-number,
+.notice-number-cell {
+  width: 80px;
+}
+
+.notice-col-type,
+.notice-type-cell {
+  width: 120px;
+}
+
+.notice-col-date,
+.notice-date-cell {
+  width: 150px;
+}
+
 .notice-row {
   cursor: pointer;
   transition: var(--transition);
 }
 
 .notice-row:hover {
-  background-color: #f8fafc;
+  background: var(--color-navy-50);
 }
 
 .notice-row td {
   padding: 24px;
   border-bottom: 1px solid var(--color-gray-200);
+}
+
+.notice-number-cell {
+  color: var(--color-gray-400);
 }
 
 .notice-badge {
@@ -167,7 +1001,14 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
 .notice-title-cell {
   font-weight: 600;
   color: var(--color-navy-900);
-  font-size: 1.1rem;
+  font-size: 1.08rem;
+}
+
+.notice-summary-cell {
+  margin-top: 4px;
+  font-size: 0.9rem;
+  color: var(--color-gray-400);
+  font-weight: 400;
 }
 
 .notice-date-cell {
@@ -176,7 +1017,20 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
   white-space: nowrap;
 }
 
-/* Notice Detail */
+.notice-pagination {
+  margin-top: 56px;
+  display: flex;
+  justify-content: center;
+}
+
+.notice-page-button {
+  min-width: 42px;
+  padding: 8px 16px;
+  background: var(--color-navy-900);
+  border-color: var(--color-navy-900);
+  color: var(--color-white);
+}
+
 .notice-content-area {
   max-width: 800px;
   margin: 0 auto;
@@ -189,10 +1043,13 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
   text-align: center;
 }
 
-.notice-header h1 {
-  font-size: 2.5rem;
+.notice-badge-header {
   margin-bottom: 16px;
-  color: var(--color-navy-900);
+}
+
+.notice-header h1 {
+  font-size: 2.45rem;
+  margin-bottom: 16px;
 }
 
 .notice-meta {
@@ -210,144 +1067,482 @@ h1, h2, h3, h4 { letter-spacing: -0.02em; color: var(--color-navy-900); }
   margin-bottom: 64px;
 }
 
+.notice-body p + p {
+  margin-top: 24px;
+}
+
 .notice-footer {
   border-top: 1px solid var(--color-gray-200);
   padding-top: 32px;
   display: flex;
   justify-content: space-between;
-}
-
-@media (max-width: 768px) {
-  .notice-table th:nth-child(1), .notice-table td:nth-child(1) { display: none; }
-  .notice-header h1 { font-size: 1.75rem; }
-}
-
-/* Corporate Detail Styles (Cambridge Style) */
-.philosophy-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: var(--color-gray-200); /* Border effect */
-  border: 1px solid var(--color-gray-200);
-}
-
-.philosophy-item {
-  background: white;
-  padding: 60px 40px;
-  text-align: center;
-  transition: var(--transition);
-}
-
-.philosophy-item:hover {
-  background: var(--color-navy-50);
-}
-
-.philosophy-number {
-  display: block;
-  font-size: 0.875rem;
-  font-weight: 800;
-  color: var(--color-blue-600);
-  margin-bottom: 20px;
-  letter-spacing: 0.1em;
-}
-
-.ceo-signature {
-  margin-top: 40px;
-  display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 16px;
 }
 
-.signature-line {
-  width: 60px;
-  height: 1px;
-  background: var(--color-navy-900);
-}
-
-.signature-text {
-  font-family: 'Cormorant Garamond', serif; /* Or any classic serif */
-  font-size: 1.5rem;
-  font-style: italic;
-  font-weight: 600;
-  color: var(--color-navy-900);
-}
-
-/* Refined History */
-.history-container {
-  max-width: 900px;
-  margin: 0 auto;
-}
-
-.history-item {
+.notice-footer-actions {
   display: flex;
-  gap: 60px;
-  padding-bottom: 60px;
-  position: relative;
+  gap: 12px;
 }
 
-.history-item::before {
-  content: '';
-  position: absolute;
-  left: 110px;
-  top: 10px;
-  bottom: 0;
-  width: 1px;
-  background: var(--color-gray-200);
+.notice-footer .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
-.history-item:last-child::before { display: none; }
+.notice-state-button,
+.category-state-button {
+  margin-top: 20px;
+}
 
-.history-year {
-  width: 110px;
-  font-size: 1.5rem;
-  font-weight: 800;
+.product-card-grid {
+  gap: 24px;
+}
+
+.product-category-card {
+  display: block;
+}
+
+.product-category-card-body {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 34px 28px;
+  border: 1px solid var(--color-gray-200);
+  border-radius: var(--radius-md);
+  background: var(--color-white);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.product-category-card:hover .product-category-card-body {
+  transform: translateY(-5px);
+  border-color: var(--color-blue-600);
+  box-shadow: var(--shadow-lg);
+}
+
+.product-category-title {
+  color: var(--color-blue-600);
+}
+
+.product-category-link {
+  margin-top: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   color: var(--color-navy-900);
-  text-align: right;
-  flex-shrink: 0;
-}
-
-.history-dot {
-  position: absolute;
-  left: 106px;
-  top: 10px;
-  width: 9px;
-  height: 9px;
-  border-radius: 50%;
-  background: var(--color-blue-600);
-  z-index: 2;
-}
-
-.history-content {
-  padding-top: 4px;
-}
-
-.history-content h4 {
-  font-size: 1.125rem;
   font-weight: 700;
-  margin-bottom: 8px;
-  color: var(--color-navy-900);
 }
 
-@media (max-width: 768px) {
-  .philosophy-grid { grid-template-columns: 1fr; }
-  .history-item { gap: 20px; }
-  .history-year { width: 70px; font-size: 1.25rem; }
-  .history-item::before, .history-dot { left: 86px; }
+.product-category-tabs {
+  margin-bottom: 40px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
-/* Empty State UI */
+.product-category-tab {
+  padding: 8px 16px;
+  font-size: 0.92rem;
+}
+
+.product-category-tab.active {
+  background: var(--color-navy-900);
+  color: var(--color-white);
+  border-color: var(--color-navy-900);
+}
+
 .empty-state {
   text-align: center;
-  padding: 80px 0;
+  padding: 80px 24px;
   background: var(--color-navy-50);
   border-radius: var(--radius-md);
   border: 1px dashed var(--color-gray-200);
+  margin: 40px 0;
 }
+
 .empty-icon {
-  width: 64px; height: 64px;
-  background: var(--color-gray-200);
+  width: 64px;
+  height: 64px;
+  background: var(--color-gray-100);
   border-radius: 50%;
   margin: 0 auto 24px;
-  display: flex; align-items: center; justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-gray-600);
+  font-size: 1.5rem;
+}
+
+.empty-title {
+  margin-bottom: 8px;
+  color: var(--color-navy-800);
+}
+
+.empty-message {
+  max-width: 460px;
+  margin: 0 auto 24px;
+  font-size: 0.95rem;
+}
+
+.not-found {
+  text-align: center;
+}
+
+.not-found p {
+  margin-bottom: 24px;
+}
+
+.desktop-only {
+  display: inline;
+}
+
+@media (max-width: 1024px) {
+  .section {
+    padding: 88px 0;
+  }
+
+  .display-1 {
+    font-size: 3rem;
+  }
+
+  .heading-1 {
+    font-size: 2.2rem;
+  }
+
+  .heading-2 {
+    font-size: 1.85rem;
+  }
+
+  .home-split-grid {
+    gap: 28px;
+  }
+
+  .home-split-image-el {
+    height: 420px;
+  }
+
+  .company-ceo-grid {
+    grid-template-columns: 1fr;
+    gap: 48px;
+  }
+
+  .company-ceo-image-wrap {
+    min-height: 0;
+  }
+
+  .company-ceo-image-bg {
+    right: 0;
+    bottom: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --header-height: 72px;
+  }
+
+  .container {
+    padding: 0 16px;
+  }
+
+  .section {
+    padding: 72px 0;
+  }
+
+  .display-1 {
+    font-size: 2.2rem;
+  }
+
+  .heading-1 {
+    font-size: 1.9rem;
+  }
+
+  .heading-2,
+  .section-header h2 {
+    font-size: 1.55rem;
+  }
+
+  .body-text {
+    font-size: 1rem;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .global-nav {
+    position: absolute;
+    top: calc(var(--header-height) - 1px);
+    left: 16px;
+    right: 16px;
+    background: var(--color-white);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    padding: 10px;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition: var(--transition);
+  }
+
+  .global-nav.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .global-nav ul {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 2px;
+  }
+
+  .nav-link {
+    padding: 12px;
+    border-radius: 6px;
+  }
+
+  .nav-link::after {
+    display: none;
+  }
+
+  .nav-link.active {
+    background: var(--color-navy-50);
+  }
+
+  .site-footer {
+    padding: 44px 0;
+  }
+
+  .footer-grid {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .footer-copyright {
+    text-align: left;
+  }
+
+  .page-hero {
+    min-height: 300px;
+  }
+
+  .page-hero-content {
+    padding: 0 16px 36px;
+  }
+
+  .page-hero p {
+    font-size: 1rem;
+  }
+
+  .home-hero {
+    min-height: 560px;
+  }
+
+  .home-hero-eyebrow {
+    font-size: 0.82rem;
+    letter-spacing: 0.2em;
+  }
+
+  .home-hero-title {
+    margin-bottom: 18px;
+  }
+
+  .home-hero-desc {
+    margin-bottom: 28px;
+  }
+
+  .home-hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .home-hero-actions .btn {
+    width: 100%;
+  }
+
+  .home-scroll-indicator {
+    display: none;
+  }
+
+  .philosophy-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .philosophy-item {
+    padding: 36px 24px;
+  }
+
+  .home-split-grid,
+  .home-split-grid-reverse {
+    grid-template-columns: 1fr;
+  }
+
+  .home-split-grid-reverse .home-split-image,
+  .home-split-grid-reverse .home-split-text {
+    order: initial;
+  }
+
+  .home-split-grid + .home-split-grid {
+    margin-top: 64px;
+  }
+
+  .home-split-heading {
+    font-size: 1.8rem;
+  }
+
+  .home-split-image-el {
+    height: 280px;
+  }
+
+  .home-cta-title {
+    font-size: 1.9rem;
+  }
+
+  .company-ceo-title {
+    font-size: 1.95rem;
+  }
+
+  .ceo-signature {
+    gap: 12px;
+  }
+
+  .company-ceo-image {
+    height: 360px;
+  }
+
+  .history-item {
+    gap: 20px;
+  }
+
+  .history-year {
+    width: 72px;
+    font-size: 1.2rem;
+  }
+
+  .history-item::before,
+  .history-dot {
+    left: 84px;
+  }
+
+  .company-cta-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .company-cta-actions .btn {
+    width: 100%;
+  }
+
+  .inquiry-form-wrap {
+    padding: 30px 20px;
+  }
+
+  .inquiry-row {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+
+  .notice-list-toolbar {
+    align-items: flex-start;
+  }
+
+  .notice-search-wrap {
+    max-width: none;
+  }
+
+  .notice-table th,
+  .notice-table td {
+    padding: 14px 12px;
+  }
+
+  .notice-col-number,
+  .notice-col-type,
+  .notice-number-cell,
+  .notice-type-cell {
+    display: none;
+  }
+
+  .notice-title-cell {
+    font-size: 1rem;
+  }
+
+  .notice-date-cell {
+    font-size: 0.82rem;
+  }
+
+  .notice-header h1 {
+    font-size: 1.6rem;
+  }
+
+  .notice-meta {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .notice-body {
+    font-size: 1rem;
+  }
+
+  .notice-footer {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .notice-footer .btn {
+    width: 100%;
+  }
+
+  .notice-footer-actions {
+    width: 100%;
+  }
+
+  .notice-footer-actions .btn {
+    flex: 1;
+  }
+
+  .product-category-tabs {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 8px;
+  }
+
+  .product-category-tab {
+    white-space: nowrap;
+  }
+
+  .empty-state {
+    padding: 56px 20px;
+  }
+
+  .desktop-only {
+    display: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .display-1 {
+    font-size: 1.95rem;
+  }
+
+  .home-hero {
+    min-height: 500px;
+  }
+
+  .home-cta-title {
+    font-size: 1.6rem;
+  }
+
+  .company-ceo-title {
+    font-size: 1.7rem;
+  }
+
+  .notice-col-date,
+  .notice-date-cell {
+    display: none;
+  }
 }


### PR DESCRIPTION
## 📣 Related Issue

- close #5

<br><br>

## 📝 Summary

- 모바일에서 깨지던 헤더/메뉴/푸터 레이아웃 반응형 구조로 수정
- 고정 2열/고정 높이 기반 페이지를 모바일 1열 중심으로 재구성
- 전역 스타일을 클래스 기반으로 정리하고 브레이크포인트(1024/768/480) 대응

<br><br>

## 🙏 Details

- Header에 모바일 햄버거 메뉴와 토글 상태 관리 추가
- Home/Company/Inquiry/Notice/Product 페이지의 인라인 고정 스타일을 반응형 클래스 스타일로 교체
- Notice 목록/상세의 모바일 가독성(컬럼 축소, 메타/버튼 스택) 개선
- EmptyState 및 Product 카드/카테고리 탭 UI를 모바일 기준으로 정비
- 빌드 검증 완료 (
> ecogad_client@1.0.0 build
> vite build

vite v6.4.1 building for production...
transforming...
✓ 57 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.93 kB │ gzip:  0.53 kB
dist/assets/index-BYb6-m2T.css   20.00 kB │ gzip:  4.52 kB
dist/assets/index-k_o9MJq4.js   258.22 kB │ gzip: 82.13 kB
✓ built in 1.16s)