### PR TITLE
feat: 모바일 좌우 여백 확대

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1245,7 +1245,7 @@ h4 {
   }
 
   .container {
-    padding: 0 16px;
+    padding: 0 20px;
   }
 
   .section {
@@ -1276,8 +1276,8 @@ h4 {
   .global-nav {
     position: absolute;
     top: calc(var(--header-height) - 1px);
-    left: 16px;
-    right: 16px;
+    left: 20px;
+    right: 20px;
     background: var(--color-white);
     border: 1px solid var(--color-gray-200);
     border-radius: var(--radius-md);
@@ -1332,7 +1332,7 @@ h4 {
   }
 
   .page-hero-content {
-    padding: 0 16px 36px;
+    padding: 0 20px 36px;
   }
 
   .page-hero p {


### PR DESCRIPTION
## 📣 Related Issue

- close #7

<br><br>

## 📝 Summary

- 모바일 공통 컨테이너 좌우 여백을 16px에서 20px로 확대
- 모바일 메뉴 드롭다운 좌우 정렬값을 컨테이너 여백과 동일하게 조정
- 페이지 히어로 콘텐츠 좌우 여백을 동일 기준으로 조정

<br><br>

## 🙏 Details

- 파일: `src/styles/global.css`
- 변경 항목
  - `@media (max-width: 768px)` 내 `.container` 패딩 `0 20px`
  - `@media (max-width: 768px)` 내 `.global-nav` 좌우 `20px`
  - `@media (max-width: 768px)` 내 `.page-hero-content` 패딩 `0 20px 36px`
- 검증: `npm run build` 성공
