### PR TITLE
feat: 모바일 전 페이지 좌우 여백 추가 확대

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,7 +17,7 @@
 
   --container-width: 1280px;
   --header-height: 80px;
-  --mobile-inline-padding: 24px;
+  --mobile-inline-padding: 28px;
 
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
@@ -1535,7 +1535,7 @@ h4 {
 
 @media (max-width: 480px) {
   :root {
-    --mobile-inline-padding: 22px;
+    --mobile-inline-padding: 26px;
   }
 
   .display-1 {


### PR DESCRIPTION
## 📣 Related Issue

- close #11

<br><br>

## 📝 Summary

- 모바일 뷰 기준 전 페이지 좌우 여백을 직전 증가폭만큼 추가 확대
- 공통 레이아웃/히어로/모바일 메뉴에 동일 여백 기준이 일괄 적용되도록 조정

<br><br>

## 🙏 Details

- 파일: `src/styles/global.css`
- 변경 항목
  - 전역 모바일 여백 변수 상향: `--mobile-inline-padding: 24px -> 28px`
  - 초소형 모바일 여백 변수 상향: `--mobile-inline-padding: 22px -> 26px` (`max-width: 480px`)
- 영향 범위
  - `.container`, `.page-hero-content`, `.global-nav` 등 변수 참조 구간 전체에 동일 적용
- 검증: `npm run build` 성공
