### PR TITLE
feat: 모바일 섹션 여백 덮어쓰기 문제 수정

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,7 +76,8 @@ button {
 }
 
 .section {
-  padding: 100px 0;
+  padding-top: 100px;
+  padding-bottom: 100px;
 }
 
 .bg-gray {
@@ -1243,6 +1244,7 @@ h4 {
 @media (max-width: 768px) {
   :root {
     --header-height: 72px;
+    --mobile-inline-padding: max(40px, 8vw);
   }
 
   .container {
@@ -1250,7 +1252,8 @@ h4 {
   }
 
   .section {
-    padding: 72px 0;
+    padding-top: 72px;
+    padding-bottom: 72px;
   }
 
   .display-1 {
@@ -1535,7 +1538,7 @@ h4 {
 
 @media (max-width: 480px) {
   :root {
-    --mobile-inline-padding: 26px;
+    --mobile-inline-padding: max(34px, 8vw);
   }
 
   .display-1 {


### PR DESCRIPTION
## 📣 Related Issue

- close #13

<br><br>

## 📝 Summary

- 모바일에서 일부 페이지가 좌우 여백 없이 붙어 보이던 원인을 수정
- `section`과 `container`를 동시에 사용하는 구조에서 발생한 패딩 덮어쓰기 문제를 제거

<br><br>

## 🙏 Details

- 파일: `src/styles/global.css`
- 원인
  - `.section { padding: 100px 0; }` / 모바일 `.section { padding: 72px 0; }`가
    `section.container` 요소의 좌우 패딩(`.container`)을 `0`으로 덮어씀
- 조치
  - `.section` 패딩을 수직축만 적용하도록 변경
    - `padding-top`, `padding-bottom`만 지정
  - 모바일(`max-width: 768px`)도 동일하게 수직축만 지정
- 결과
  - `section.container`에 설정된 모바일 좌우 여백이 전 페이지에서 정상 반영
- 검증: `npm run build` 성공
