### PR TITLE
feat: 로고/명함 기반 브랜드 아이덴티티 반영

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="ecogad는 산업용 대형 공조 필터와 클린룸 유지보수 솔루션을 제공합니다." />
+    <meta name="description" content="ECO GOD는 산업용 필터 설계·제조 전문 기업으로 다양한 공정 환경에 맞춤 솔루션을 제공합니다." />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="ecogad | 산업용 공조 필터 전문 기업" />
-    <meta property="og:description" content="공항, 반도체 공장, 클린룸을 위한 고성능 필터 제조 및 유지보수" />
-    <title>ecogad | 산업용 공조 필터 전문 기업</title>
+    <meta property="og:title" content="ECO GOD | 산업용 필터 설계·제조 전문 기업" />
+    <meta property="og:description" content="화력발전소, 집진기, 수처리, 공기정화 설비를 위한 산업용 필터 솔루션" />
+    <title>ECO GOD | 산업용 필터 설계·제조 전문 기업</title>
     <link rel="preconnect" href="https://images.unsplash.com" />
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,20 +8,28 @@ import InquiryPage from "./pages/InquiryPage";
 import NoticeListPage from "./pages/NoticeListPage"; // Existing file
 import NoticeDetailPage from "./pages/NoticeDetailPage"; // Existing file
 import NotFoundPage from "./pages/NotFoundPage"; // Existing file
+import brandLogo from "./assets/ecogod-logo-wordmark.svg";
 
 // Simple Footer for completeness
 const Footer = () => (
   <footer className="site-footer">
     <div className="container footer-inner">
-      <div className="footer-brand">ECOGAD</div>
+      <div className="footer-brand">
+        <img src={brandLogo} alt="ECO GOD 로고" className="footer-brand-logo" loading="lazy" />
+        <span className="footer-brand-name">ECO GOD Co.,Ltd.</span>
+      </div>
       <div className="footer-grid">
         <div>
-          <p>경기도 화성시 동탄첨단산업1로 27</p>
-          <p>대표전화: 031-123-4567 | 팩스: 031-123-4568</p>
-          <p>이메일: sales@ecogad.co.kr</p>
+          <p>(주)에코가드 | ECO GOD Co.,Ltd.</p>
+          <p>대표: 전철환</p>
+          <p>주소: 경기도 안산시 단원구 만해로 205 타원TAKRAIII 3층 A-315호</p>
+          <p>Tel. 031-380-0329 | Mob. 010-5223-5879</p>
+          <p>Fax. 031-437-6360 | E-mail. filter0524@naver.com</p>
         </div>
         <div className="footer-copyright">
-          <p>Copyright © 2026 ECOGAD. All rights reserved.</p>
+          <p>산업용 필터 설계·제조 전문</p>
+          <p>[화력발전소/방전가공기/공기정화용/집진기/수처리/유압오일/MIST/COMP]</p>
+          <p>Copyright © {new Date().getFullYear()} ECO GOD. All rights reserved.</p>
         </div>
       </div>
     </div>

--- a/src/assets/ecogod-logo-full.svg
+++ b/src/assets/ecogod-logo-full.svg
@@ -1,0 +1,24 @@
+<svg width="760" height="230" viewBox="0 0 760 230" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">ECO GOD CI</title>
+  <desc id="desc">ECO GOD 로고와 슬로건이 포함된 회사 CI</desc>
+  <rect width="760" height="230" fill="none"/>
+
+  <g transform="translate(90 26)">
+    <text x="0" y="88" fill="#4A4A4D" font-family="Arial Black, Arial, sans-serif" font-size="92" font-weight="900" letter-spacing="1.2">ec</text>
+
+    <polygon points="200,22 241,45 241,91 200,114 159,91 159,45" fill="#E8B034"/>
+    <polygon points="292,22 333,45 333,91 292,114 251,91 251,45" fill="#E8B034"/>
+
+    <path d="M229 31C229 21 235.4 12 244.8 8.2" stroke="#4A4A4D" stroke-width="6" stroke-linecap="round"/>
+    <path d="M261 31C261 21 267.4 12 276.8 8.2" stroke="#4A4A4D" stroke-width="6" stroke-linecap="round"/>
+
+    <ellipse cx="246" cy="67" rx="17" ry="24" fill="#FFFFFF"/>
+    <rect x="232" y="52" width="28" height="7" rx="3.5" fill="#4A4A4D"/>
+    <rect x="232" y="64" width="28" height="7" rx="3.5" fill="#4A4A4D"/>
+    <rect x="232" y="76" width="28" height="7" rx="3.5" fill="#4A4A4D"/>
+
+    <text x="340" y="88" fill="#4A4A4D" font-family="Arial Black, Arial, sans-serif" font-size="92" font-weight="900" letter-spacing="1.2">d</text>
+
+    <text x="102" y="152" fill="#4A4A4D" font-family="Arial, sans-serif" font-size="36" font-weight="500" letter-spacing="6">THE SMILE OF HONEYBEE</text>
+  </g>
+</svg>

--- a/src/assets/ecogod-logo-wordmark.svg
+++ b/src/assets/ecogod-logo-wordmark.svg
@@ -1,0 +1,22 @@
+<svg width="540" height="116" viewBox="0 0 540 116" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">ECO GOD 로고</title>
+  <desc id="desc">육각형 심볼과 텍스트로 구성된 ECO GOD 워드마크</desc>
+  <rect width="540" height="116" fill="none"/>
+
+  <g transform="translate(0 10)">
+    <text x="6" y="72" fill="#4A4A4D" font-family="Arial Black, Arial, sans-serif" font-size="76" font-weight="900" letter-spacing="1.2">ec</text>
+
+    <polygon points="158,18 192,37 192,75 158,94 124,75 124,37" fill="#E8B034"/>
+    <polygon points="234,18 268,37 268,75 234,94 200,75 200,37" fill="#E8B034"/>
+
+    <path d="M182 26C182 18.5 186.8 11.8 193.8 8.9" stroke="#4A4A4D" stroke-width="5" stroke-linecap="round"/>
+    <path d="M208 26C208 18.5 212.8 11.8 219.8 8.9" stroke="#4A4A4D" stroke-width="5" stroke-linecap="round"/>
+
+    <ellipse cx="196" cy="56" rx="15" ry="21" fill="#FFFFFF"/>
+    <rect x="184" y="43" width="24" height="6" rx="3" fill="#4A4A4D"/>
+    <rect x="184" y="53" width="24" height="6" rx="3" fill="#4A4A4D"/>
+    <rect x="184" y="63" width="24" height="6" rx="3" fill="#4A4A4D"/>
+
+    <text x="274" y="72" fill="#4A4A4D" font-family="Arial Black, Arial, sans-serif" font-size="76" font-weight="900" letter-spacing="1.2">d</text>
+  </g>
+</svg>

--- a/src/hooks/usePageMeta.js
+++ b/src/hooks/usePageMeta.js
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-const BASE_TITLE = "ecogad";
+const BASE_TITLE = "ECO GOD";
 
 export default function usePageMeta(pageTitle, description) {
   useEffect(() => {

--- a/src/layouts/AppLayout.jsx
+++ b/src/layouts/AppLayout.jsx
@@ -24,9 +24,9 @@ export default function AppLayout() {
     script.text = JSON.stringify({
       "@context": "https://schema.org",
       "@type": "Organization",
-      name: "ecogad",
-      url: "https://www.ecogad.com",
-      description: "산업용 대형 공조 필터 제조 및 클린룸 유지보수 전문 기업"
+      name: "ECO GOD Co.,Ltd.",
+      url: "https://ecogadfront.vercel.app",
+      description: "산업용 필터 설계·제조 전문 기업"
     });
     document.head.appendChild(script);
   }, []);
@@ -39,8 +39,8 @@ export default function AppLayout() {
     <div className="site-shell">
       <header className="site-header">
         <div className="container header-inner">
-          <NavLink to="/" className="brand" aria-label="ecogad 홈으로 이동">
-            ECOGAD
+          <NavLink to="/" className="brand" aria-label="ECO GOD 홈으로 이동">
+            ECO GOD
           </NavLink>
           <button
             type="button"
@@ -82,8 +82,8 @@ export default function AppLayout() {
 
       <footer className="site-footer">
         <div className="container footer-inner">
-          <p>© {new Date().getFullYear()} ecogad. All rights reserved.</p>
-          <p>산업용 공조 필터 제조 및 클린룸 유지보수 전문</p>
+          <p>© {new Date().getFullYear()} ECO GOD. All rights reserved.</p>
+          <p>산업용 필터 설계·제조 전문</p>
         </div>
       </footer>
     </div>

--- a/src/layouts/Header.jsx
+++ b/src/layouts/Header.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import brandLogo from "../assets/ecogod-logo-wordmark.svg";
 
 const navLinks = [
   { name: "회사소개", path: "/company" },
@@ -29,9 +30,9 @@ const Header = () => {
   return (
     <header className={`site-header ${scrolled ? "is-scrolled" : ""}`}>
       <div className="container header-inner">
-        <Link to="/" className="brand" aria-label="ecogad 홈으로 이동">
-          <span className="brand-mark" aria-hidden="true" />
-          ECOGAD
+        <Link to="/" className="brand" aria-label="ECO GOD 홈으로 이동">
+          <img src={brandLogo} alt="ECO GOD 로고" className="brand-logo" />
+          <span className="sr-only">ECO GOD</span>
         </Link>
 
         <button

--- a/src/pages/CeoGreetingPage.jsx
+++ b/src/pages/CeoGreetingPage.jsx
@@ -2,30 +2,31 @@ import usePageMeta from "../hooks/usePageMeta";
 import PageHero from "../components/common/PageHero";
 
 export default function CeoGreetingPage() {
-  usePageMeta("CEO 인사말", "에코가드 CEO 인사말을 확인하세요.");
+  usePageMeta("CEO 인사말", "ECO GOD 대표이사 인사말을 확인하세요.");
 
   return (
     <>
       <PageHero
         title="CEO 인사말"
-        description="정밀한 기술과 책임 있는 품질로 고객의 신뢰를 지켜가겠습니다."
+        description="산업용 필터 성능과 현장 신뢰를 최우선으로, 고객의 생산 환경을 안정적으로 지원하겠습니다."
         imageUrl="https://images.unsplash.com/photo-1454165804606-c3d57bc86b40?auto=format&fit=crop&w=1800&q=80"
         imageAlt="회의실에서 산업 프로젝트를 검토하는 장면"
       />
 
       <section className="section container ceo-message" aria-labelledby="ceo-message-title">
-        <h2 id="ceo-message-title">고객과 함께 성장하는 기술 파트너가 되겠습니다</h2>
+        <h2 id="ceo-message-title">고객 현장의 요구에 끝까지 답하는 파트너가 되겠습니다</h2>
         <p>
-          ecogad는 산업 현장에서 요구되는 공기 품질 기준을 정확히 이해하고, 설계부터 제조,
-          운영 지원까지 일관된 품질 체계를 제공하기 위해 노력해 왔습니다.
+          안녕하십니까, ECO GOD 대표이사 전철환입니다. 저희는 산업 현장에서 요구되는
+          공기 품질 기준을 정확히 반영한 필터 설계와 제조를 핵심 가치로 삼고 있습니다.
         </p>
         <p>
-          앞으로도 고객 공정의 안정성과 생산성을 높일 수 있도록 기술 검증과 현장 대응을
-          지속적으로 고도화하겠습니다.
+          화력발전소, 방전가공기, 집진기, 수처리 등 다양한 운전 환경에서 검증된 제품과
+          신속한 기술 지원으로 고객 설비의 안정성과 생산성을 높이겠습니다.
         </p>
 
-        <div className="signature-box" aria-label="CEO 서명 이미지 자리">
-          <span>CEO Signature Placeholder</span>
+        <div className="signature-box" aria-label="CEO 서명 영역">
+          <strong>전철환</strong>
+          <span>ECO GOD Co.,Ltd. 대표이사</span>
         </div>
       </section>
     </>

--- a/src/pages/CompanyPage.jsx
+++ b/src/pages/CompanyPage.jsx
@@ -2,54 +2,95 @@ import React from "react";
 import { Link } from "react-router-dom";
 import PageHero from "../components/common/PageHero";
 import SectionHeader from "../components/common/SectionHeader";
+import brandFullLogo from "../assets/ecogod-logo-full.svg";
 
 const histories = [
-  { year: "2025", title: "사업 확장 및 고도화", text: "전국 유지보수 통합 서비스 표준 프로세스 운영 개시" },
-  { year: "2021", title: "주요 인프라 수주", text: "인천국제공항 제2터미널 및 반도체 공정용 케미컬 필터 공급" },
-  { year: "2018", title: "연구소 설립 및 R&D 강화", text: "부설 기술 연구소 설립 및 초고성능 ULPA 필터 국산화 성공" },
-  { year: "2012", title: "법인 설립 및 공장 준공", text: "에코가드 법인 설립 및 경기도 화성 제1공장 가동" }
+  {
+    year: "2025",
+    title: "특수 산업용 필터 라인 고도화",
+    text: "화력발전소·방전가공기·유압오일 MIST 대응 라인업을 통합 설계 체계로 개편"
+  },
+  {
+    year: "2023",
+    title: "안산 기술영업 거점 확장",
+    text: "경기도 안산시 단원구 타원TAKRAIII에 기술영업 및 고객 대응 거점을 확장 운영"
+  },
+  {
+    year: "2018",
+    title: "현장 맞춤 설계 역량 강화",
+    text: "집진기, 수처리, 공기정화 설비별 맞춤 필터 사양 설계 및 제작 프로세스 정착"
+  },
+  {
+    year: "2012",
+    title: "ECO GOD Co.,Ltd. 설립",
+    text: "산업용 필터 설계·제조 전문 기업으로 출범하여 현장 중심 생산 체계를 구축"
+  }
 ];
 
 const CompanyPage = () => {
   return (
     <div className="company-page">
       <PageHero
-        title="Who We Are"
-        subtitle="가장 맑은 숨으로 내일을 여는 기술, 에코가드의 철학입니다."
+        title="Company Introduction"
+        subtitle="산업 현장의 공기 품질 문제를 해결하는 필터 엔지니어링 기업, ECO GOD입니다."
         bgImage="https://images.unsplash.com/photo-1565043589221-1a6fd9ae45c7?auto=format&fit=crop&w=1800&q=80"
         imageAlt="산업 시설 전경"
       />
+
+      <section className="section company-identity-section">
+        <div className="container company-identity-grid">
+          <img
+            src={brandFullLogo}
+            alt="ECO GOD 회사 CI"
+            className="company-identity-logo"
+            loading="lazy"
+          />
+
+          <article className="company-identity-card" aria-label="회사 기본 정보">
+            <h2 className="heading-2">(주)에코가드 | ECO GOD Co.,Ltd.</h2>
+            <p className="body-text company-identity-description">
+              THE SMILE OF HONEYBEE 철학을 기반으로 산업용 필터를 설계·제조하며,
+              설비 특성에 맞춘 실사용 성능 중심 솔루션을 제공합니다.
+            </p>
+            <ul className="company-identity-list">
+              <li>대표: 전철환 (CHEOL HWAN JEON)</li>
+              <li>주소: 경기도 안산시 단원구 만해로 205 타원TAKRAIII 3층 A-315호</li>
+              <li>Tel. 031-380-0329 / Mob. 010-5223-5879 / Fax. 031-437-6360</li>
+              <li>E-mail. filter0524@naver.com</li>
+            </ul>
+          </article>
+        </div>
+      </section>
 
       <section className="section company-ceo-section">
         <div className="container company-ceo-grid">
           <div>
             <span className="section-eyebrow company-ceo-eyebrow">CEO GREETING</span>
             <h2 className="heading-1 company-ceo-title">
-              공정의 안정성과 근로자의 건강을
+              현장에 필요한 성능을,
               <br />
-              지키는 가장 완벽한 필터링 기술.
+              정확하게 설계하고 끝까지 책임지겠습니다.
             </h2>
             <div className="body-text company-ceo-body">
               <p>
-                안녕하십니까? 에코가드 대표이사 김철수입니다.
-                우리가 숨 쉬는 공기는 단순한 환경을 넘어 산업의 품질과 생명에 직결됩니다.
+                안녕하십니까. ECO GOD 대표이사 전철환입니다. 저희는 산업용 필터를 단순한
+                소모품이 아닌, 설비 안정성과 작업자 안전을 지키는 핵심 장비로 바라보고 있습니다.
               </p>
               <p>
-                캠브리지 필터의 정밀한 엔지니어링 정신을 이어받아, 에코가드는 0.1μm의 입자
-                하나까지 놓치지 않는 고성능 필터 국산화에 매진해왔습니다. 반도체, 제약, 의료,
-                그리고 대형 공공 인프라에 이르기까지 에코가드의 기술이 닿지 않는 곳이 없습니다.
+                화력발전소, 방전가공기, 집진기, 수처리, 공기정화 시스템 등 각 현장은
+                운전 조건과 오염원 특성이 다릅니다. ECO GOD는 현장 조건 분석을 바탕으로
+                구조, 소재, 유지주기까지 최적화된 필터를 설계·제조합니다.
               </p>
               <p>
-                우리는 단순한 필터 제조사를 넘어, 고객사의 공정 안정성을 위한 최적의
-                공조 솔루션 파트너가 될 것을 약속드립니다. 언제나 가장 맑은 공기로
-                여러분의 비즈니스에 보탬이 되겠습니다.
+                앞으로도 고객 생산 환경의 연속성과 효율을 높이는 신뢰 가능한 파트너로서,
+                검증된 품질과 빠른 기술 대응으로 보답하겠습니다.
               </p>
             </div>
 
             <div className="ceo-signature">
               <span className="signature-line" />
-              <span className="company-ceo-role">에코가드 주식회사 대표이사</span>
-              <span className="signature-text">Kim Chul Soo</span>
+              <span className="company-ceo-role">ECO GOD Co.,Ltd. 대표이사</span>
+              <span className="signature-text">CHEOL HWAN JEON</span>
             </div>
           </div>
 
@@ -57,7 +98,7 @@ const CompanyPage = () => {
             <div className="company-ceo-image-bg" aria-hidden="true" />
             <img
               src="https://images.unsplash.com/photo-1556761175-5973dc0f32e7?auto=format&fit=crop&w=1632&q=80"
-              alt="CEO 이미지"
+              alt="ECO GOD 대표 인사 이미지"
               className="company-ceo-image"
               loading="lazy"
             />
@@ -69,29 +110,29 @@ const CompanyPage = () => {
         <div className="container">
           <SectionHeader
             eyebrow="MANAGEMENT PHILOSOPHY"
-            title="기업 이념"
-            description="에코가드는 세 가지 핵심 가치를 바탕으로 고객의 신뢰에 보답합니다."
+            title="기업 운영 원칙"
+            description="ECO GOD는 다음 세 가지 원칙으로 고객 현장의 성능 신뢰를 지켜갑니다."
           />
           <div className="philosophy-grid">
             <article className="philosophy-item">
               <span className="philosophy-number">01</span>
-              <h3 className="heading-3">Integrity (무결성)</h3>
+              <h3 className="heading-3">Precision Design</h3>
               <p className="body-text">
-                제품의 성능은 곧 신뢰입니다. 타협하지 않는 품질 기준으로 무결점 필터만을 생산합니다.
+                설비 조건과 오염 특성을 데이터로 분석해 현장에 맞는 필터 구조를 설계합니다.
               </p>
             </article>
             <article className="philosophy-item">
               <span className="philosophy-number">02</span>
-              <h3 className="heading-3">Innovation (혁신)</h3>
+              <h3 className="heading-3">Operational Reliability</h3>
               <p className="body-text">
-                정체된 기술은 도태됩니다. 나노 소재 및 스마트 모니터링 시스템 등 혁신을 선도합니다.
+                초기 성능뿐 아니라 운전 기간 전체의 안정성을 기준으로 제작과 검증을 수행합니다.
               </p>
             </article>
             <article className="philosophy-item">
               <span className="philosophy-number">03</span>
-              <h3 className="heading-3">Sustainability (지속가능성)</h3>
+              <h3 className="heading-3">Rapid Field Support</h3>
               <p className="body-text">
-                환경을 보호하는 필터가 되어야 합니다. 에너지 효율 극대화와 친환경 소재 적용에 앞장섭니다.
+                납기, 교체, 유지보수 대응을 표준화하여 고객의 다운타임 최소화를 지원합니다.
               </p>
             </article>
           </div>
@@ -103,7 +144,7 @@ const CompanyPage = () => {
           <SectionHeader
             eyebrow="HISTORY"
             title="연혁"
-            description="에코가드는 고객과 함께 정직한 성장의 길을 걸어왔습니다."
+            description="ECO GOD는 산업용 필터 전문성과 현장 신뢰를 기반으로 성장해 왔습니다."
           />
           <div className="history-container">
             {histories.map((history) => (
@@ -122,18 +163,18 @@ const CompanyPage = () => {
 
       <section className="section company-cta-section">
         <div className="container company-cta-container">
-          <span className="section-eyebrow company-cta-eyebrow">GLOBAL NETWORK</span>
-          <h2 className="heading-2 company-cta-title">한국을 넘어 세계 최고의 공기질 솔루션으로.</h2>
+          <span className="section-eyebrow company-cta-eyebrow">ENGINEERING PARTNER</span>
+          <h2 className="heading-2 company-cta-title">현장 조건 기반 맞춤 필터 상담을 진행합니다.</h2>
           <p className="body-text company-cta-desc">
-            에코가드는 동남아시아 및 중동 시장의 주요 클린룸 프로젝트를 수행하며
-            세계적인 기술력을 인정받고 있습니다.
+            산업 설비 조건, 운전 환경, 교체 주기를 함께 검토해 가장 실효성 있는 제품과
+            운영 계획을 제안드립니다.
           </p>
           <div className="company-cta-actions">
             <Link to="/products" className="btn btn-primary">
               제품 라인업 확인
             </Link>
             <Link to="/inquiry" className="btn btn-outline btn-outline-light">
-              지사 및 네트워크 문의
+              견적 및 기술 문의
             </Link>
           </div>
         </div>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -34,23 +34,23 @@ const HomePage = () => {
         />
 
         <div className="container home-hero-content">
-          <span className="section-eyebrow home-hero-eyebrow">ENGINEERING PURITY SINCE 2012</span>
+          <span className="section-eyebrow home-hero-eyebrow">THE SMILE OF HONEYBEE</span>
           <h1 className="display-1 home-hero-title">
-            The Standard of
+            Precision Filters for
             <br />
-            <span>Industrial Purity.</span>
+            <span>Industrial Reliability.</span>
           </h1>
           <p className="body-text home-hero-desc">
-            반도체 클린룸에서 공항까지, 에코가드의 초정밀 필터 솔루션은
+            화력발전소, 집진기, 수처리 설비부터 고청정 클린룸까지 ECO GOD의 산업용 필터 솔루션은
             <br className="desktop-only" />
-            산업의 품질과 생명을 지키는 가장 완벽한 기준이 됩니다.
+            현장 운전 안정성과 공기질 기준을 동시에 만족시키는 실전형 표준을 제공합니다.
           </p>
           <div className="home-hero-actions">
             <Link to="/products" className="btn btn-primary">
               EXPLORE SOLUTIONS
             </Link>
             <Link to="/company" className="btn btn-ghost-light">
-              ABOUT ECOGAD
+              ABOUT ECO GOD
             </Link>
           </div>
         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,17 +1,18 @@
 :root {
-  --color-navy-900: #0f172a;
-  --color-navy-800: #1e293b;
-  --color-navy-50: #f8fafc;
+  --color-navy-900: #2f3035;
+  --color-navy-800: #46484f;
+  --color-navy-50: #f5f3ee;
 
-  --color-blue-600: #0066ff;
-  --color-blue-700: #0052cc;
-  --color-cyan-500: #06b6d4;
+  --color-blue-600: #e8b034;
+  --color-blue-700: #c6901e;
+  --color-cyan-500: #b9861a;
 
   --color-white: #ffffff;
-  --color-gray-100: #f1f5f9;
-  --color-gray-200: #e2e8f0;
-  --color-gray-400: #94a3b8;
-  --color-gray-600: #475569;
+  --color-gray-100: #f7f6f2;
+  --color-gray-200: #ddd9ce;
+  --color-gray-400: #999487;
+  --color-gray-600: #5f5b51;
+  --color-accent-rgb: 232 176 52;
 
   --font-main: "Pretendard Variable", "Inter", -apple-system, sans-serif;
 
@@ -42,7 +43,7 @@ body,
 body {
   font-family: var(--font-main);
   color: var(--color-navy-800);
-  background-color: var(--color-white);
+  background-color: var(--color-gray-100);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
@@ -102,14 +103,14 @@ button {
   right: 0;
   z-index: 1000;
   height: var(--header-height);
-  background: rgb(255 255 255 / 0.85);
+  background: rgb(247 246 242 / 0.88);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid transparent;
   transition: var(--transition);
 }
 
 .site-header.is-scrolled {
-  background: rgb(255 255 255 / 0.96);
+  background: rgb(247 246 242 / 0.97);
   border-bottom-color: var(--color-gray-200);
 }
 
@@ -122,21 +123,30 @@ button {
 }
 
 .brand {
-  font-size: 1.4rem;
-  font-weight: 800;
   color: var(--color-navy-900);
   display: inline-flex;
   align-items: center;
-  gap: 10px;
+  gap: 14px;
   letter-spacing: 0.02em;
   z-index: 1001;
 }
 
-.brand-mark {
-  width: 24px;
-  height: 24px;
-  border-radius: 4px;
-  background: var(--color-blue-600);
+.brand-logo {
+  width: auto;
+  height: 44px;
+  object-fit: contain;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .menu-toggle {
@@ -217,13 +227,28 @@ button {
   background: var(--color-navy-900);
   color: rgb(255 255 255 / 0.86);
   padding: 60px 0;
+  border-top: 1px solid rgb(232 176 52 / 0.28);
 }
 
 .footer-brand {
   margin-bottom: 24px;
-  font-weight: 700;
-  font-size: 1.2rem;
   color: var(--color-white);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.footer-brand-logo {
+  width: auto;
+  height: 48px;
+  object-fit: contain;
+}
+
+.footer-brand-name {
+  font-size: 1.05rem;
+  letter-spacing: 0.06em;
+  font-weight: 700;
 }
 
 .footer-grid {
@@ -233,8 +258,13 @@ button {
   font-size: 0.92rem;
 }
 
+.footer-grid p + p {
+  margin-top: 6px;
+}
+
 .footer-copyright {
   text-align: right;
+  color: rgb(255 255 255 / 0.72);
 }
 
 h1,
@@ -623,6 +653,43 @@ h4 {
   justify-content: center;
 }
 
+.company-identity-section {
+  background: var(--color-white);
+}
+
+.company-identity-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 38px;
+  align-items: center;
+}
+
+.company-identity-logo {
+  width: 100%;
+  max-width: 620px;
+  margin: 0 auto;
+}
+
+.company-identity-card {
+  padding: 36px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-gray-200);
+  background: var(--color-navy-50);
+  box-shadow: var(--shadow-sm);
+}
+
+.company-identity-description {
+  margin-top: 14px;
+}
+
+.company-identity-list {
+  margin-top: 20px;
+  display: grid;
+  gap: 10px;
+  color: var(--color-navy-800);
+  font-weight: 500;
+}
+
 .company-ceo-section {
   background: var(--color-white);
 }
@@ -702,7 +769,7 @@ h4 {
   height: 520px;
   object-fit: cover;
   border-radius: var(--radius-md);
-  filter: grayscale(30%) contrast(1.08);
+  filter: contrast(1.04) saturate(0.94);
 }
 
 .history-container {
@@ -828,7 +895,7 @@ h4 {
 
 .form-input:focus {
   border-color: var(--color-blue-600);
-  box-shadow: 0 0 0 3px rgb(0 102 255 / 0.12);
+  box-shadow: 0 0 0 3px rgb(var(--color-accent-rgb) / 0.18);
 }
 
 .form-textarea {
@@ -892,7 +959,7 @@ h4 {
 
 .notice-search-input:focus {
   border-color: var(--color-blue-600);
-  box-shadow: 0 0 0 3px rgb(0 102 255 / 0.12);
+  box-shadow: 0 0 0 3px rgb(var(--color-accent-rgb) / 0.18);
 }
 
 .notice-search-icon {
@@ -1197,6 +1264,40 @@ h4 {
   margin-bottom: 24px;
 }
 
+.ceo-message {
+  max-width: 920px;
+}
+
+.ceo-message h2 {
+  font-size: 2.2rem;
+  margin-bottom: 20px;
+}
+
+.ceo-message p + p {
+  margin-top: 18px;
+}
+
+.signature-box {
+  margin-top: 30px;
+  border: 1px solid var(--color-gray-200);
+  border-left: 4px solid var(--color-blue-600);
+  border-radius: var(--radius-sm);
+  padding: 18px 20px;
+  background: var(--color-navy-50);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.signature-box strong {
+  color: var(--color-navy-900);
+  font-size: 1.1rem;
+}
+
+.signature-box span {
+  color: var(--color-gray-600);
+}
+
 .desktop-only {
   display: inline;
 }
@@ -1224,6 +1325,11 @@ h4 {
 
   .home-split-image-el {
     height: 420px;
+  }
+
+  .company-identity-grid {
+    grid-template-columns: 1fr;
+    gap: 28px;
   }
 
   .company-ceo-grid {
@@ -1277,6 +1383,10 @@ h4 {
     display: inline-flex;
   }
 
+  .brand-logo {
+    height: 36px;
+  }
+
   .global-nav {
     position: absolute;
     top: calc(var(--header-height) - 1px);
@@ -1320,6 +1430,14 @@ h4 {
 
   .site-footer {
     padding: 44px 0;
+  }
+
+  .footer-brand-logo {
+    height: 42px;
+  }
+
+  .footer-brand-name {
+    font-size: 0.95rem;
   }
 
   .footer-grid {
@@ -1450,6 +1568,10 @@ h4 {
     width: 100%;
   }
 
+  .ceo-message h2 {
+    font-size: 1.7rem;
+  }
+
   .inquiry-form-wrap {
     padding: 32px 24px;
   }
@@ -1560,6 +1682,10 @@ h4 {
   .notice-col-date,
   .notice-date-cell {
     display: none;
+  }
+
+  .brand-logo {
+    height: 30px;
   }
 
   .history-year {


### PR DESCRIPTION
## 작업 내용\n- 제공된 CI 스타일을 반영한 로고 SVG(워드마크/풀버전) 신규 추가\n- 헤더/푸터에 신규 로고 적용 및 명함 정보(주소/연락처/대표자)로 갱신\n- 전역 컬러 팔레트를 꿀색+다크그레이 톤으로 재구성\n- 회사소개/CEO 인사말/홈 메인 카피를 ECO GOD 브랜드 기준으로 수정\n- SEO 메타 타이틀/설명 문구를 최신 브랜딩으로 업데이트\n\n## 검증\n- npm run build\n\nCloses #15